### PR TITLE
fix: tolerant *T/T read path, unmarshal-error self-heal, always write back after a successful evaluator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,9 @@ go 1.23.2
 
 require (
 	github.com/DataDog/zstd v1.5.6
+	github.com/alicebob/miniredis/v2 v2.38.0
 	github.com/cloudflare/golz4 v0.0.0-20240916140612-caecf3c00c06
+	github.com/gammazero/deque v1.1.0
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/hashicorp/golang-lru v1.0.2
 	github.com/klauspost/compress v1.17.11
@@ -15,7 +17,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
-	github.com/gammazero/deque v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/DataDog/zstd v1.5.6 h1:LbEglqepa/ipmmQJUDnSsfvA8e8IStVcGaFWDuxvGOY=
 github.com/DataDog/zstd v1.5.6/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
+github.com/alicebob/miniredis/v2 v2.38.0 h1:nZAzCR+Lj+Vxk4ZXzm2NuKq2O33RXj1XxJ2e2uP9jiw=
+github.com/alicebob/miniredis/v2 v2.38.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cloudflare/golz4 v0.0.0-20240916140612-caecf3c00c06 h1:6aQNgrBLzcUBaJHQjMk4X+jDo9rQtu5E0XNLhRV6pOk=
@@ -28,6 +30,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781 h1:DzZ89McO9/gWPsQXS/FVKAlG02ZjaQ6AlZRBimEYOd0=
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e h1:fLOSk5Q00efkSvAm+4xcoXD+RRmLmmulPn5I3Y9F2EM=

--- a/interface.go
+++ b/interface.go
@@ -158,8 +158,9 @@ func (c *Cache[T]) SetIndirect(key string, value *T, linkResolver func(*T) strin
 }
 
 // GetOrComputeEx tries to get value from cache.
-// If not found, it computes the value using provided evaluator function and stores it into cache.
-// In case of other errors the value is evaluated but not stored in the cache.
+// If the cache has no servable value (miss, wrong type, transient engine
+// error or validator rejection), it computes the value using the provided
+// evaluator function and stores it into cache (subject to writeApprover).
 // Additional parameters (can be nil):
 // validator - validates cache records, on false evaluator will be run again (new results will not be validated)
 // linkResolver - checks if cached value is a link and returns the key it's pointing to

--- a/interface.go
+++ b/interface.go
@@ -22,7 +22,6 @@ package cachier
 
 import (
 	"errors"
-	"reflect"
 	"regexp"
 	"slices"
 	"strings"
@@ -179,22 +178,18 @@ func (c *Cache[T]) GetOrComputeEx(key string, evaluator func() (*T, error), vali
 	}
 
 	value, evaluatorErr := evaluator()
-
-	if evaluatorErr == nil {
-		// value evaluted correctly
-		if err == ErrNotFound {
-			if writeApprover == nil || writeApprover(value) {
-				// Key not found in cache
-				c.setIndirectNoLock(key, value, linkResolver, linkGenerator)
-			}
-
-		}
-
-		// ignore cache get error
-		return value, nil
+	if evaluatorErr != nil {
+		return nil, evaluatorErr
 	}
 
-	return nil, evaluatorErr
+	// Reaching the evaluator means the cache had no servable value (miss,
+	// wrong type, transient engine error or validator rejection), so the
+	// fresh value always replaces whatever is stored.
+	if writeApprover == nil || writeApprover(value) {
+		c.setIndirectNoLock(key, value, linkResolver, linkGenerator)
+	}
+
+	return value, nil
 }
 
 // DeletePredicate deletes all keys matching the supplied predicate, returns number of deleted keys
@@ -265,16 +260,11 @@ func (c *Cache[T]) Peek(key string) (*T, error) {
 	}
 
 	untypedValue, err := c.engine.Peek(key)
-	if err == nil {
-		typedValue, ok := untypedValue.(T)
-		if ok {
-			return &typedValue, nil
-		} else {
-			err = ErrNotFound
-		}
+	if err != nil {
+		return nil, err
 	}
 
-	return nil, err
+	return assertCached[T](untypedValue)
 }
 
 // Delete removes a key from cache
@@ -311,23 +301,25 @@ func (c *Cache[T]) getNoLock(key string) (*T, error) {
 	}
 
 	untypedValue, err := c.engine.Get(key)
-	if err == nil {
-		if reflect.ValueOf(value).Kind() == reflect.Ptr {
-			typedValue, ok := untypedValue.(*T)
-			if !ok {
-				return nil, ErrWrongDataType
-			}
-			return typedValue, nil
-		} else {
-			typedValue, ok := untypedValue.(T)
-			if !ok {
-				return nil, ErrWrongDataType
-			}
-			return &typedValue, nil
-		}
+	if err != nil {
+		return nil, err
 	}
 
-	return nil, err
+	return assertCached[T](untypedValue)
+}
+
+// assertCached converts a value read from a cache engine into *T. Engines
+// return either the raw *T that was stored (e.g. LRU without compression) or
+// a value produced by an unmarshal callback, which may be T or *T depending
+// on the callback's convention — all of them must be servable.
+func assertCached[T any](v interface{}) (*T, error) {
+	if typedValue, ok := v.(*T); ok {
+		return typedValue, nil
+	}
+	if typedValue, ok := v.(T); ok {
+		return &typedValue, nil
+	}
+	return nil, ErrWrongDataType
 }
 
 // setNoLock stores a key-value pair into cache

--- a/lru.go
+++ b/lru.go
@@ -77,7 +77,7 @@ func (lc *LRUCache) Get(key string) (v interface{}, err error) {
 	}
 
 	output, err := lc.decompress(key, value)
-	if err != nil {
+	if err != nil && err != ErrNotFound {
 		lc.logger.Error("lru: error decompressing data: ", err)
 	}
 	return output, err
@@ -122,7 +122,7 @@ func (lc *LRUCache) Peek(key string) (v interface{}, err error) {
 	}
 
 	output, err := lc.decompress(key, value)
-	if err != nil {
+	if err != nil && err != ErrNotFound {
 		lc.logger.Error("lru: error decompressing data: ", err)
 	}
 	return output, err

--- a/lru.go
+++ b/lru.go
@@ -97,7 +97,11 @@ func (lc *LRUCache) decompress(key string, value interface{}) (interface{}, erro
 	}
 
 	var result interface{}
-	lc.unmarshal(input, &result)
+	if err := lc.unmarshal(input, &result); err != nil {
+		lc.logger.Error("lru: error unmarshaling data with key: ", key, " error: ", err)
+		lc.Delete(key)
+		return nil, ErrNotFound
+	}
 	return result, nil
 }
 

--- a/read_path_test.go
+++ b/read_path_test.go
@@ -1,0 +1,280 @@
+package cachier
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/datasapiens/cachier/compression"
+	"github.com/datasapiens/cachier/utils"
+	"github.com/go-redis/redis/v8"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testEntry is the cached value type used across the read-path tests.
+type testEntry struct {
+	ID  int
+	Key string
+}
+
+// newTestCache wraps an engine in a Cache without starting the background
+// write loop so tests can flush the write queue deterministically.
+func newTestCache[T any](engine CacheEngine) *Cache[T] {
+	return &Cache[T]{
+		engine:       engine,
+		computeLocks: *utils.NewMutexMap(),
+		writeQueue:   newWriteQueue[T](),
+		logger:       DummyLogger{},
+	}
+}
+
+// flushWriteQueue synchronously drains all pending operations into the
+// engine, replicating one writeLoop pass.
+func flushWriteQueue[T any](t *testing.T, c *Cache[T]) {
+	t.Helper()
+	for {
+		op, ok := c.writeQueue.StartWriting()
+		if !ok {
+			return
+		}
+		var err error
+		switch op := op.(type) {
+		case *queueOperationSet[T]:
+			err = c.engine.Set(op.Key, op.Value)
+		case *queueOperationDelete:
+			err = c.engine.Delete(op.Key)
+		case *queueOperationDeletePredicate:
+			var keys []string
+			keys, err = c.engine.Keys()
+			if err == nil {
+				for _, key := range keys {
+					if op.Predicate(key) {
+						if err = c.engine.Delete(key); err != nil {
+							break
+						}
+					}
+				}
+			}
+		case *queueOperationPurge:
+			err = c.engine.Purge()
+		}
+		c.writeQueue.DoneWriting(err == nil)
+		require.NoError(t, err)
+	}
+}
+
+func jsonMarshal(value interface{}) ([]byte, error) {
+	return json.Marshal(value)
+}
+
+// valueUnmarshal produces a value-typed result (*value = res), one of the two
+// unmarshaler conventions in the wild.
+func valueUnmarshal(b []byte, value *interface{}) error {
+	var res testEntry
+	if err := json.Unmarshal(b, &res); err != nil {
+		return err
+	}
+	*value = res
+	return nil
+}
+
+// pointerUnmarshal produces a pointer-typed result (*value = &res), the other
+// unmarshaler convention.
+func pointerUnmarshal(b []byte, value *interface{}) error {
+	var res testEntry
+	if err := json.Unmarshal(b, &res); err != nil {
+		return err
+	}
+	*value = &res
+	return nil
+}
+
+func newZstdEngine(t *testing.T) *compression.Engine {
+	t.Helper()
+	engine, err := compression.NewEngine(compression.ProviderIDZstd, nil)
+	require.NoError(t, err)
+	return engine
+}
+
+func newMiniredisCache(t *testing.T, unmarshal func([]byte, *interface{}) error) (*RedisCache, *miniredis.Miniredis) {
+	t.Helper()
+	server := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: server.Addr()})
+	return NewRedisCache(client, "", jsonMarshal, unmarshal, 0, nil), server
+}
+
+// TestReadPathHitsAcrossEngineConventions covers the H7/M9 matrix: Get, Peek
+// and GetOrCompute must all hit regardless of whether the engine returns the
+// raw stored *T (LRU without compression) or an unmarshaler-produced value
+// (redis, LRU with compression) of either convention.
+func TestReadPathHitsAcrossEngineConventions(t *testing.T) {
+	configs := []struct {
+		name      string
+		newEngine func(t *testing.T) CacheEngine
+	}{
+		{"lru-plain", func(t *testing.T) CacheEngine {
+			engine, err := NewLRUCache(300, nil, nil, nil)
+			require.NoError(t, err)
+			return engine
+		}},
+		{"lru-compressed-value-unmarshaler", func(t *testing.T) CacheEngine {
+			engine, err := NewLRUCache(300, jsonMarshal, valueUnmarshal, newZstdEngine(t))
+			require.NoError(t, err)
+			return engine
+		}},
+		{"lru-compressed-pointer-unmarshaler", func(t *testing.T) CacheEngine {
+			engine, err := NewLRUCache(300, jsonMarshal, pointerUnmarshal, newZstdEngine(t))
+			require.NoError(t, err)
+			return engine
+		}},
+		{"redis-value-unmarshaler", func(t *testing.T) CacheEngine {
+			engine, _ := newMiniredisCache(t, valueUnmarshal)
+			return engine
+		}},
+		{"redis-pointer-unmarshaler", func(t *testing.T) CacheEngine {
+			engine, _ := newMiniredisCache(t, pointerUnmarshal)
+			return engine
+		}},
+	}
+
+	for _, cfg := range configs {
+		t.Run(cfg.name, func(t *testing.T) {
+			c := newTestCache[testEntry](cfg.newEngine(t))
+			want := testEntry{ID: 1, Key: "payload"}
+			require.NoError(t, c.Set("k", &want))
+			flushWriteQueue(t, c)
+
+			got, err := c.Get("k")
+			require.NoError(t, err, "Get must hit after the flush")
+			assert.Equal(t, want, *got)
+
+			got, err = c.Peek("k")
+			require.NoError(t, err, "Peek must hit after the flush")
+			assert.Equal(t, want, *got)
+
+			evaluatorCalled := false
+			got, err = c.GetOrCompute("k", func() (*testEntry, error) {
+				evaluatorCalled = true
+				return &testEntry{ID: 99, Key: "recomputed"}, nil
+			})
+			require.NoError(t, err)
+			assert.False(t, evaluatorCalled, "GetOrCompute must serve the cached value, not recompute")
+			assert.Equal(t, want, *got)
+		})
+	}
+}
+
+// TestWrongTypeYieldsErrWrongDataType pins down that widening the asserts
+// does not silently accept genuinely foreign values.
+func TestWrongTypeYieldsErrWrongDataType(t *testing.T) {
+	engine, err := NewLRUCache(300, nil, nil, nil)
+	require.NoError(t, err)
+	c := newTestCache[testEntry](engine)
+	require.NoError(t, engine.Set("k", "definitely not a testEntry"))
+
+	_, err = c.Get("k")
+	assert.ErrorIs(t, err, ErrWrongDataType)
+
+	_, err = c.Peek("k")
+	assert.ErrorIs(t, err, ErrWrongDataType)
+}
+
+// TestRedisCorruptPayloadSelfHeals covers M11 (+ the M2 corollary): a payload
+// that fails the unmarshal callback is deleted on read, reads as ErrNotFound,
+// and the next compute both returns and persists the fresh value.
+func TestRedisCorruptPayloadSelfHeals(t *testing.T) {
+	engine, server := newMiniredisCache(t, valueUnmarshal)
+	c := newTestCache[testEntry](engine)
+
+	require.NoError(t, server.Set("corrupt", "{not json"))
+
+	_, err := c.Get("corrupt")
+	assert.ErrorIs(t, err, ErrNotFound, "corrupt entry must read as a miss")
+	assert.False(t, server.Exists("corrupt"), "corrupt entry must be deleted on read")
+
+	want := testEntry{ID: 2, Key: "recomputed"}
+	got, err := c.GetOrComputeEx("corrupt", func() (*testEntry, error) {
+		return &want, nil
+	}, nil, nil, nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, want, *got)
+
+	flushWriteQueue(t, c)
+	assert.True(t, server.Exists("corrupt"), "recomputed value must be persisted to the engine")
+	got, err = c.Get("corrupt")
+	require.NoError(t, err)
+	assert.Equal(t, want, *got)
+}
+
+// TestLRUCompressedCorruptPayloadSelfHeals is the LRU-side M11 case: the
+// decompress path must delete entries whose unmarshal fails instead of
+// serving nil forever.
+func TestLRUCompressedCorruptPayloadSelfHeals(t *testing.T) {
+	corruptMarshal := func(value interface{}) ([]byte, error) {
+		return []byte("{not json"), nil
+	}
+	engine, err := NewLRUCache(300, corruptMarshal, valueUnmarshal, newZstdEngine(t))
+	require.NoError(t, err)
+	c := newTestCache[testEntry](engine)
+
+	seed := testEntry{ID: 1, Key: "seed"}
+	require.NoError(t, c.Set("corrupt", &seed))
+	flushWriteQueue(t, c)
+
+	_, err = c.Get("corrupt")
+	assert.ErrorIs(t, err, ErrNotFound, "corrupt entry must read as a miss")
+	assert.False(t, engine.lru.Contains("corrupt"), "corrupt entry must be deleted on read")
+}
+
+// TestValidatorRejectionWritesBackRecompute is the M2 repro: when the
+// validator rejects a cached entry, the successful recompute must replace it
+// in the engine so unconstrained readers see the fresh value.
+func TestValidatorRejectionWritesBackRecompute(t *testing.T) {
+	engine, err := NewLRUCache(300, nil, nil, nil)
+	require.NoError(t, err)
+	c := newTestCache[testEntry](engine)
+
+	stale := testEntry{ID: 1, Key: "stale"}
+	require.NoError(t, c.Set("k", &stale))
+	flushWriteQueue(t, c)
+
+	fresh := testEntry{ID: 2, Key: "fresh"}
+	got, err := c.GetOrComputeEx("k",
+		func() (*testEntry, error) { return &fresh, nil },
+		func(v *testEntry) bool { return v.ID != stale.ID },
+		nil, nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, fresh, *got)
+
+	flushWriteQueue(t, c)
+	got, err = c.Get("k")
+	require.NoError(t, err)
+	assert.Equal(t, fresh, *got, "recomputed value must replace the validator-rejected entry")
+}
+
+// TestWriteApproverStillBlocksWriteBack guards the always-write-back change:
+// writeApprover=false must keep the recompute out of the cache.
+func TestWriteApproverStillBlocksWriteBack(t *testing.T) {
+	engine, err := NewLRUCache(300, nil, nil, nil)
+	require.NoError(t, err)
+	c := newTestCache[testEntry](engine)
+
+	stale := testEntry{ID: 1, Key: "stale"}
+	require.NoError(t, c.Set("k", &stale))
+	flushWriteQueue(t, c)
+
+	fresh := testEntry{ID: 2, Key: "fresh"}
+	got, err := c.GetOrComputeEx("k",
+		func() (*testEntry, error) { return &fresh, nil },
+		func(v *testEntry) bool { return false },
+		nil, nil,
+		func(v *testEntry) bool { return false })
+	require.NoError(t, err)
+	assert.Equal(t, fresh, *got, "the computed value is still returned to the caller")
+
+	flushWriteQueue(t, c)
+	got, err = c.Get("k")
+	require.NoError(t, err)
+	assert.Equal(t, stale, *got, "writeApprover=false must block the write-back")
+}

--- a/redis.go
+++ b/redis.go
@@ -97,7 +97,11 @@ func (rc *RedisCache) Get(key string) (v interface{}, err error) {
 	}
 
 	var result interface{}
-	rc.unmarshal(input, &result)
+	if err := rc.unmarshal(input, &result); err != nil {
+		rc.logger.Error("redis: error unmarshaling data with key: ", key, " error: ", err)
+		rc.Delete(key)
+		return nil, ErrNotFound
+	}
 	return result, nil
 }
 


### PR DESCRIPTION
Read-path remediation from g2's cache audit (findings H7, M9, M11, M2 — PR 4 of the remediation plan, see g2 `_project-docs/cache-fix-plan.md` and `_project-docs/cache-audit-2026-07-02.md`).

## What changes

1. **H7 + M9 — tolerant `*T`/`T` read path.** New `assertCached[T]` helper tries `.(*T)` then `.(T)`, else `ErrWrongDataType`; used by both `getNoLock` and `Peek`. Previously `getNoLock` only accepted `*T` (its `.(T)` branch was dead code — the reflect probe ran on the typed-nil `*T` from `writeQueue.Get`, so `Kind()` was always `Ptr`) while `Peek` only accepted `T`: no engine configuration made Get **and** Peek both work. Now both engine conventions work everywhere — raw `*T` (LRU without compression, custom engines) and unmarshaler-produced `T`/`*T` (redis, LRU with compression).
2. **M11 — unmarshal-error self-heal.** `RedisCache.Get` and the LRU decompress path no longer discard the unmarshal callback's error: on failure they log, delete the key, and return `ErrNotFound` — mirroring the existing decompression self-heal. Previously a corrupt payload defeated its key permanently (never deleted, recompute never persisted).
3. **M2 — always write back after a successful evaluator.** `GetOrComputeEx` no longer gates the write-back on `err == ErrNotFound`: every path that reaches the evaluator means the cache had no servable value (miss, wrong type, transient engine error, validator rejection), so the fresh value always replaces the stored one (still subject to `writeApprover`). `GetOrCompute` (non-Ex) is unchanged apart from the helper.

## Consumer-visible semantics (deliberate, all widening)

- Redis-mode reads that previously failed with `ErrWrongDataType` (value-typed unmarshalers) start hitting.
- Validator-rejected entries are replaced by the strictly-fresher recompute instead of persisting forever.
- `Peek` on a genuinely wrong-typed entry now returns `ErrWrongDataType` (previously misreported as `ErrNotFound`), consistent with `Get`.
- Corrupt-entry deletion is destructive-on-read but idempotent and logged.
- **No key-format change** — existing redis entries were always written correctly and become valid hits; no migration or flush needed.

## Tests

`go test -race` on the package: red commit first (all failures land exactly where the audit predicted), then the fix. Matrix over {LRU plain, LRU zstd, redis} × {value-typed, pointer-typed unmarshaler}: Get/Peek/GetOrCompute hits, wrong-type still `ErrWrongDataType`, corrupt-payload self-heal + recompute persistence, validator-rejection write-back, `writeApprover=false` guard. `miniredis` added as a test-only dependency so the redis matrix runs without a server. Tests construct `Cache` without the background write loop and drain the queue synchronously (deterministic, no sleeps); the drain helper intentionally mirrors `writeLoop`'s dispatch rather than extracting a shared method — extraction would silently fix the `err :=` shadow in the Purge case, which is finding M10 and belongs to the follow-up invalidation PR.

## Notes

- Pre-existing on master and untouched here: `utils.TestMutexMap` fails under `go test -race` (race inside `utils/mutex_map_test.go`); the audit's follow-up PRs are the natural place to address it.
- **Tagging hazard:** g2 currently pins `v1.2.5-0.20251212115736-7e95510ab00c`, which lives on the unmerged `feat/redis-client-v9.17.2` branch (master + one commit bumping redis-go). If v1.3.0 is tagged from master before that branch merges, g2's bump would silently drop the redis-client upgrade it runs today — merge `feat/redis-client-v9.17.2` first (or rebase this decision explicitly) before tagging.
- Out of scope by decision (2026-07-06), reserved for the follow-up PR: synchronous invalidation, delete-path semantics, redis SCAN, `Close()`/Flush.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
