### PR TITLE
Async invalidation with compute-token fencing, purge shadow fix, SCAN + batched UNLINK, Close() (H4, M12, M10)

### DIFF
--- a/compute_fencing_test.go
+++ b/compute_fencing_test.go
@@ -1,0 +1,134 @@
+package cachier
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newLRUTestCache builds a Cache over a plain LRU engine without the
+// background write loop (house pattern: newTestCache + flushWriteQueue).
+func newLRUTestCache(t *testing.T) *Cache[testEntry] {
+	t.Helper()
+	engine, err := NewLRUCache(300, nil, nil, nil)
+	require.NoError(t, err)
+	return newTestCache[testEntry](engine)
+}
+
+// waitForAsyncWriteBack blocks until GetOrCompute's spawned write-back
+// goroutine for key has finished: that goroutine holds key's compute lock
+// until after its write attempt, so acquiring the lock is a deterministic
+// barrier — no sleeps needed.
+func waitForAsyncWriteBack(c *Cache[testEntry], key string) {
+	m := c.computeLocks.Lock(key)
+	c.computeLocks.Unlock(key, m)
+}
+
+// The H4 scenario: an invalidation fires while a compute for a matching key
+// is still running. The compute's result must be returned to the caller but
+// must never be written back — otherwise the pre-event value is resurrected
+// and served until the next (possibly never-recurring) invalidation event.
+// Firing the invalidation from inside the evaluator is deterministic: the
+// compute is by construction in flight at that moment.
+
+func TestGetOrComputeEx_DeletePredicateMidCompute_SkipsWriteBack(t *testing.T) {
+	c := newLRUTestCache(t)
+
+	want := testEntry{ID: 1, Key: "computed-against-stale-data"}
+	got, err := c.GetOrComputeEx("k", func() (*testEntry, error) {
+		require.NoError(t, c.DeletePredicate(func(key string) bool { return key == "k" }))
+		return &want, nil
+	}, nil, nil, nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, want, *got, "the computed value is still returned to the caller")
+
+	flushWriteQueue(t, c)
+	_, err = c.Get("k")
+	assert.ErrorIs(t, err, ErrNotFound, "a write fenced by a mid-compute invalidation must never land")
+}
+
+func TestGetOrComputeEx_PurgeMidCompute_SkipsWriteBack(t *testing.T) {
+	c := newLRUTestCache(t)
+
+	want := testEntry{ID: 1, Key: "computed-against-stale-data"}
+	got, err := c.GetOrComputeEx("k", func() (*testEntry, error) {
+		require.NoError(t, c.Purge())
+		return &want, nil
+	}, nil, nil, nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, want, *got)
+
+	flushWriteQueue(t, c)
+	_, err = c.Get("k")
+	assert.ErrorIs(t, err, ErrNotFound, "a write fenced by a mid-compute purge must never land")
+}
+
+func TestGetOrComputeEx_NonMatchingPredicateMidCompute_KeepsWrite(t *testing.T) {
+	c := newLRUTestCache(t)
+
+	want := testEntry{ID: 1, Key: "fresh"}
+	got, err := c.GetOrComputeEx("k", func() (*testEntry, error) {
+		require.NoError(t, c.DeletePredicate(func(key string) bool { return key == "other" }))
+		return &want, nil
+	}, nil, nil, nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, want, *got)
+
+	flushWriteQueue(t, c)
+	got, err = c.Get("k")
+	require.NoError(t, err, "a non-matching invalidation must not suppress the write")
+	assert.Equal(t, want, *got)
+}
+
+func TestGetOrCompute_DeletePredicateMidCompute_SkipsAsyncWriteBack(t *testing.T) {
+	c := newLRUTestCache(t)
+
+	want := testEntry{ID: 1, Key: "computed-against-stale-data"}
+	got, err := c.GetOrCompute("k", func() (*testEntry, error) {
+		require.NoError(t, c.DeletePredicate(func(key string) bool { return key == "k" }))
+		return &want, nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, want, *got)
+
+	waitForAsyncWriteBack(c, "k")
+	flushWriteQueue(t, c)
+	_, err = c.Get("k")
+	assert.ErrorIs(t, err, ErrNotFound, "GetOrCompute's async write-back must honor a mid-compute invalidation")
+}
+
+func TestGetOrCompute_PurgeMidCompute_SkipsAsyncWriteBack(t *testing.T) {
+	c := newLRUTestCache(t)
+
+	want := testEntry{ID: 1, Key: "computed-against-stale-data"}
+	got, err := c.GetOrCompute("k", func() (*testEntry, error) {
+		require.NoError(t, c.Purge())
+		return &want, nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, want, *got)
+
+	waitForAsyncWriteBack(c, "k")
+	flushWriteQueue(t, c)
+	_, err = c.Get("k")
+	assert.ErrorIs(t, err, ErrNotFound, "GetOrCompute's async write-back must honor a mid-compute purge")
+}
+
+func TestGetOrCompute_NonMatchingPredicateMidCompute_KeepsAsyncWrite(t *testing.T) {
+	c := newLRUTestCache(t)
+
+	want := testEntry{ID: 1, Key: "fresh"}
+	got, err := c.GetOrCompute("k", func() (*testEntry, error) {
+		require.NoError(t, c.DeletePredicate(func(key string) bool { return key == "other" }))
+		return &want, nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, want, *got)
+
+	waitForAsyncWriteBack(c, "k")
+	flushWriteQueue(t, c)
+	got, err = c.Get("k")
+	require.NoError(t, err, "a non-matching invalidation must not suppress the async write")
+	assert.Equal(t, want, *got)
+}

--- a/interface.go
+++ b/interface.go
@@ -96,13 +96,20 @@ func MakeCache[T any](engine CacheEngine, logger Logger) *Cache[T] {
 // multiple goroutines. All cache methods keep working after Close — reads,
 // computes and the synchronous invalidations are unaffected — but writes
 // enqueued after the final drain are never flushed to the engine, so stop
-// producing writes before calling Close.
+// producing writes before calling Close. On a Cache built without
+// MakeCache (in-package tests) there is no write loop and Close is a no-op.
 func (c *Cache[T]) Close() {
 	c.closeOnce.Do(func() {
-		c.ticker.Stop()
-		close(c.done)
+		if c.ticker != nil {
+			c.ticker.Stop()
+		}
+		if c.done != nil {
+			close(c.done)
+		}
 	})
-	<-c.stopped
+	if c.stopped != nil {
+		<-c.stopped
+	}
 }
 
 // GetOrCompute tries to get value from cache.

--- a/interface.go
+++ b/interface.go
@@ -98,13 +98,17 @@ func MakeCache[T any](engine CacheEngine, logger Logger) *Cache[T] {
 	return cache
 }
 
-// Close stops the background write loop, waiting for it to perform one
-// final best-effort drain and exit. Idempotent and safe to call from
-// multiple goroutines. Reads and computes keep working after Close, but
-// writes AND invalidations enqueued after the final drain never reach the
-// engine (they only mask in-process reads), so stop producing both before
-// calling Close. On a Cache built without MakeCache (in-package tests)
-// there is no write loop and Close is a no-op.
+// Close stops the background write loop, waits for it to exit, and then
+// performs one more best-effort drain to catch operations that raced the
+// loop's own final drain. Idempotent and safe to call from multiple
+// goroutines. Reads and computes keep working after Close, but a write or
+// invalidation enqueued after Close never reaches the engine — it only
+// masks in-process reads, and against a persistent engine (redis) that
+// outlives the process the invalidation is permanently lost. Quiesce EVERY
+// producer of writes and invalidations — HTTP handlers, event listeners,
+// background workers — before calling Close. On a Cache built without
+// MakeCache (in-package tests) there is no write loop to stop; Close just
+// performs the drain.
 func (c *Cache[T]) Close() {
 	c.closeOnce.Do(func() {
 		if c.ticker != nil {
@@ -116,6 +120,11 @@ func (c *Cache[T]) Close() {
 	})
 	if c.stopped != nil {
 		<-c.stopped
+	}
+	// The loop goroutine has exited (or never existed), so draining from
+	// here cannot violate StartWriting's single-consumer invariant; engineMu
+	// still serializes cycles against any concurrent Close caller.
+	for c.runOneWriteCycle() {
 	}
 }
 

--- a/interface.go
+++ b/interface.go
@@ -50,6 +50,13 @@ type CacheEngine interface {
 	Purge() error
 }
 
+// BulkDeleter is an optional CacheEngine extension: engines that can delete
+// many keys cheaply (e.g. redis via batched UNLINK) implement it, and the
+// write loop uses it instead of one Delete round trip per key.
+type BulkDeleter interface {
+	DeleteMany(keys []string) error
+}
+
 // Cache is an implementation of a cache (key-value store).
 // It needs to be provided with cache engine.
 type Cache[T any] struct {
@@ -60,10 +67,10 @@ type Cache[T any] struct {
 	statsInterval time.Duration
 	logger        Logger
 
-	// engineMu serializes every engine mutation: each write-loop cycle
-	// (StartWriting-engine-op-DoneWriting, atomic as a unit) and every
-	// synchronous invalidation's discard+engine pass. It is released
-	// between write cycles so invalidations never wait for a full drain.
+	// engineMu makes each write-loop cycle (StartWriting-engine-op-
+	// DoneWriting) atomic as a unit, so StartWriting's single-consumer
+	// invariant holds even if a drain is ever driven from more than one
+	// goroutine (e.g. tests calling runOneWriteCycle directly).
 	engineMu sync.Mutex
 
 	ticker    *time.Ticker
@@ -93,11 +100,11 @@ func MakeCache[T any](engine CacheEngine, logger Logger) *Cache[T] {
 
 // Close stops the background write loop, waiting for it to perform one
 // final best-effort drain and exit. Idempotent and safe to call from
-// multiple goroutines. All cache methods keep working after Close — reads,
-// computes and the synchronous invalidations are unaffected — but writes
-// enqueued after the final drain are never flushed to the engine, so stop
-// producing writes before calling Close. On a Cache built without
-// MakeCache (in-package tests) there is no write loop and Close is a no-op.
+// multiple goroutines. Reads and computes keep working after Close, but
+// writes AND invalidations enqueued after the final drain never reach the
+// engine (they only mask in-process reads), so stop producing both before
+// calling Close. On a Cache built without MakeCache (in-package tests)
+// there is no write loop and Close is a no-op.
 func (c *Cache[T]) Close() {
 	c.closeOnce.Do(func() {
 		if c.ticker != nil {
@@ -221,34 +228,24 @@ func (c *Cache[T]) GetOrComputeEx(key string, evaluator func() (*T, error), vali
 	return value, nil
 }
 
-// DeletePredicate synchronously deletes all keys matching the supplied
-// predicate. Queued writes for matching keys are discarded and in-flight
-// computes for them are fenced: their write-back is skipped while the
-// computed value is still returned to their callers. Returns the first
-// engine error; on failure some matching keys may already have been
-// deleted and nothing is retried — the caller owns the retry decision.
+// DeletePredicate deletes all keys matching the supplied predicate. Queued
+// writes for matching keys are discarded, in-flight computes for them are
+// fenced (their write-back is skipped while the computed value is still
+// returned to their callers), and the engine-side delete is enqueued for
+// the write loop — this call never blocks on the engine, so invalidating
+// a large keyspace adds no caller latency. Reads see the deletion
+// immediately via the queued op. Always returns nil: engine failures are
+// logged and retried head-of-line by the write loop until they succeed; a
+// hard crash before the flush loses the queued invalidation (TTL is the
+// backstop).
 func (c *Cache[T]) DeletePredicate(pred Predicate) error {
-	c.engineMu.Lock()
-	defer c.engineMu.Unlock()
+	c.writeQueue.DeletePredicate(pred)
 
-	c.writeQueue.DiscardPredicate(pred)
-
-	keys, err := c.engine.Keys()
-	if err != nil {
-		return err
-	}
-	for _, key := range keys {
-		if pred(key) {
-			if err := c.engine.Delete(key); err != nil {
-				return err
-			}
-		}
-	}
 	return nil
 }
 
-// DeleteWithPrefix synchronously removes all keys that start with the given
-// prefix. Same fencing and error semantics as DeletePredicate.
+// DeleteWithPrefix removes all keys that start with the given prefix. Same
+// fencing and write-back semantics as DeletePredicate.
 func (c *Cache[T]) DeleteWithPrefix(prefix string) error {
 	pred := func(s string) bool {
 		return strings.HasPrefix(s, prefix)
@@ -257,8 +254,8 @@ func (c *Cache[T]) DeleteWithPrefix(prefix string) error {
 	return c.DeletePredicate(pred)
 }
 
-// DeleteRegExp synchronously deletes all keys matching the supplied regexp.
-// Same fencing and error semantics as DeletePredicate.
+// DeleteRegExp deletes all keys matching the supplied regexp. Same fencing
+// and write-back semantics as DeletePredicate.
 func (c *Cache[T]) DeleteRegExp(pattern string) error {
 	re, err := regexp.Compile(pattern)
 	if err != nil {
@@ -317,31 +314,28 @@ func (c *Cache[T]) Peek(key string) (*T, error) {
 	return assertCached[T](untypedValue)
 }
 
-// Delete synchronously removes a key from the cache engine, discarding any
-// queued write for it first, and returns the engine's real error. It holds
-// the key's compute lock, so no compute for this key can be in flight
-// (GetOrCompute's write-back goroutine holds that lock until it finishes).
-// Nothing is retried on failure — the caller owns the retry decision.
+// Delete removes a key from cache: queued writes for it are discarded and
+// the engine-side delete is enqueued for the write loop. It holds the key's
+// compute lock, so no compute for this key can be in flight (GetOrCompute's
+// write-back goroutine holds that lock until it finishes). Reads see the
+// deletion immediately via the queued op. Always returns nil — see
+// DeletePredicate for the failure semantics.
 func (c *Cache[T]) Delete(key string) error {
 	mutex := c.computeLocks.Lock(key)
 	defer c.computeLocks.Unlock(key, mutex)
 
-	c.engineMu.Lock()
-	defer c.engineMu.Unlock()
-
-	c.writeQueue.Discard(key)
-	return c.engine.Delete(key)
+	c.writeQueue.Delete(key)
+	return nil
 }
 
-// Purge synchronously removes all records from the cache, discarding every
-// queued write and fencing every in-flight compute. Returns the engine's
-// real error; nothing is retried on failure.
+// Purge removes all records from the cache: every queued write is dropped,
+// every in-flight compute is fenced, and the engine purge is enqueued for
+// the write loop. Always returns nil — see DeletePredicate for the failure
+// semantics.
 func (c *Cache[T]) Purge() error {
-	c.engineMu.Lock()
-	defer c.engineMu.Unlock()
+	c.writeQueue.Purge()
 
-	c.writeQueue.DiscardPredicate(func(string) bool { return true })
-	return c.engine.Purge()
+	return nil
 }
 
 // Keys returns all the keys in cache
@@ -463,14 +457,11 @@ func (c *Cache[T]) writeLoop() {
 }
 
 // runOneWriteCycle processes at most one queued operation under engineMu,
-// so a whole StartWriting-engine-op-DoneWriting cycle is atomic relative to
-// the synchronous invalidations (which also run under engineMu); engineMu
-// is released between cycles so an invalidation never waits for a full
-// queue drain. Returns false when the caller should stop draining: the
-// queue is empty, or the op failed, stays at the front, and must wait for
-// the next tick instead of hot-spinning. Only Set ops are enqueued since
-// the invalidations became synchronous; the other cases are kept
-// defensively until the queue is simplified.
+// so a whole StartWriting-engine-op-DoneWriting cycle is atomic and
+// StartWriting's single-consumer invariant holds even if a drain is ever
+// driven from more than one goroutine. Returns false when the caller
+// should stop draining: the queue is empty, or the op failed, stays at the
+// front, and must wait for the next tick instead of hot-spinning.
 func (c *Cache[T]) runOneWriteCycle() bool {
 	c.engineMu.Lock()
 	defer c.engineMu.Unlock()
@@ -493,14 +484,13 @@ func (c *Cache[T]) runOneWriteCycle() bool {
 		var keys []string
 		keys, err = c.engine.Keys()
 		if err == nil {
+			matching := make([]string, 0, len(keys))
 			for _, key := range keys {
 				if op.Predicate(key) {
-					err = c.engine.Delete(key)
-					if err != nil {
-						break
-					}
+					matching = append(matching, key)
 				}
 			}
+			err = c.deleteKeys(matching)
 		}
 
 	case *queueOperationPurge:
@@ -514,4 +504,21 @@ func (c *Cache[T]) runOneWriteCycle() bool {
 		return false
 	}
 	return true
+}
+
+// deleteKeys removes the given keys from the engine, using the engine's
+// bulk fast path when it has one.
+func (c *Cache[T]) deleteKeys(keys []string) error {
+	if len(keys) == 0 {
+		return nil
+	}
+	if bulk, ok := c.engine.(BulkDeleter); ok {
+		return bulk.DeleteMany(keys)
+	}
+	for _, key := range keys {
+		if err := c.engine.Delete(key); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/interface.go
+++ b/interface.go
@@ -25,6 +25,7 @@ import (
 	"regexp"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/datasapiens/cachier/utils"
@@ -58,6 +59,17 @@ type Cache[T any] struct {
 	writeInterval time.Duration
 	statsInterval time.Duration
 	logger        Logger
+
+	// engineMu serializes every engine mutation: each write-loop cycle
+	// (StartWriting-engine-op-DoneWriting, atomic as a unit) and every
+	// synchronous invalidation's discard+engine pass. It is released
+	// between write cycles so invalidations never wait for a full drain.
+	engineMu sync.Mutex
+
+	ticker    *time.Ticker
+	done      chan struct{}
+	stopped   chan struct{}
+	closeOnce sync.Once
 }
 
 // MakeCache creates cache with provided engine
@@ -70,10 +82,27 @@ func MakeCache[T any](engine CacheEngine, logger Logger) *Cache[T] {
 		statsInterval: 60 * time.Second,        // Default stats interval
 		logger:        logger,
 	}
+	cache.ticker = time.NewTicker(cache.writeInterval)
+	cache.done = make(chan struct{})
+	cache.stopped = make(chan struct{})
 
 	go cache.writeLoop() // Start the write loop in a goroutine
 
 	return cache
+}
+
+// Close stops the background write loop, waiting for it to perform one
+// final best-effort drain and exit. Idempotent and safe to call from
+// multiple goroutines. All cache methods keep working after Close — reads,
+// computes and the synchronous invalidations are unaffected — but writes
+// enqueued after the final drain are never flushed to the engine, so stop
+// producing writes before calling Close.
+func (c *Cache[T]) Close() {
+	c.closeOnce.Do(func() {
+		c.ticker.Stop()
+		close(c.done)
+	})
+	<-c.stopped
 }
 
 // GetOrCompute tries to get value from cache.
@@ -87,17 +116,20 @@ func (c *Cache[T]) GetOrCompute(key string, evaluator func() (*T, error)) (*T, e
 		return value, nil
 	}
 
+	token := c.writeQueue.RegisterToken(key)
 	calculatedValue, evaluatorErr := evaluator()
 
 	if evaluatorErr == nil {
 		// Key not found on cache
 		go func() {
-			c.setNoLock(key, calculatedValue)
+			c.setNoLock(key, calculatedValue, token)
+			c.writeQueue.DeregisterToken(key, token)
 			c.computeLocks.Unlock(key, mutex)
 		}()
 		return calculatedValue, nil
 	} else {
 		// evalutation error
+		c.writeQueue.DeregisterToken(key, token)
 		c.computeLocks.Unlock(key, mutex)
 		calculatedValue = nil
 		err = evaluatorErr
@@ -109,7 +141,7 @@ func (c *Cache[T]) GetOrCompute(key string, evaluator func() (*T, error)) (*T, e
 func (c *Cache[T]) Set(key string, value *T) error {
 	mutex := c.computeLocks.Lock(key)
 	defer c.computeLocks.Unlock(key, mutex)
-	return c.setNoLock(key, value)
+	return c.setNoLock(key, value, nil)
 }
 
 // Get gets a cached value by key
@@ -139,22 +171,7 @@ func (c *Cache[T]) GetIndirect(key string, linkResolver func(*T) string) (*T, er
 func (c *Cache[T]) SetIndirect(key string, value *T, linkResolver func(*T) string, linkGenerator func(*T) *T) error {
 	mutex := c.computeLocks.Lock(key)
 	defer c.computeLocks.Unlock(key, mutex)
-	if linkGenerator != nil && linkResolver != nil {
-		if linkValue := linkGenerator(value); linkValue != nil {
-			link := linkResolver(linkValue)
-			if link != key {
-				lock := c.computeLocks.Lock(link)
-				defer c.computeLocks.Unlock(link, lock)
-				if err := c.setNoLock(key, linkValue); err != nil {
-					return err
-				}
-			}
-
-			return c.setNoLock(link, value)
-		}
-	}
-
-	return c.setNoLock(key, value)
+	return c.setIndirectNoLock(key, value, linkResolver, linkGenerator, nil)
 }
 
 // GetOrComputeEx tries to get value from cache.
@@ -178,6 +195,9 @@ func (c *Cache[T]) GetOrComputeEx(key string, evaluator func() (*T, error), vali
 		c.logger.Error("error getting value from cache: ", err)
 	}
 
+	token := c.writeQueue.RegisterToken(key)
+	defer c.writeQueue.DeregisterToken(key, token)
+
 	value, evaluatorErr := evaluator()
 	if evaluatorErr != nil {
 		return nil, evaluatorErr
@@ -185,22 +205,43 @@ func (c *Cache[T]) GetOrComputeEx(key string, evaluator func() (*T, error), vali
 
 	// Reaching the evaluator means the cache had no servable value (miss,
 	// wrong type, transient engine error or validator rejection), so the
-	// fresh value always replaces whatever is stored.
+	// fresh value always replaces whatever is stored — unless an
+	// invalidation fenced this compute while it was in flight.
 	if writeApprover == nil || writeApprover(value) {
-		c.setIndirectNoLock(key, value, linkResolver, linkGenerator)
+		c.setIndirectNoLock(key, value, linkResolver, linkGenerator, token)
 	}
 
 	return value, nil
 }
 
-// DeletePredicate deletes all keys matching the supplied predicate, returns number of deleted keys
+// DeletePredicate synchronously deletes all keys matching the supplied
+// predicate. Queued writes for matching keys are discarded and in-flight
+// computes for them are fenced: their write-back is skipped while the
+// computed value is still returned to their callers. Returns the first
+// engine error; on failure some matching keys may already have been
+// deleted and nothing is retried — the caller owns the retry decision.
 func (c *Cache[T]) DeletePredicate(pred Predicate) error {
-	c.writeQueue.DeletePredicate(pred)
+	c.engineMu.Lock()
+	defer c.engineMu.Unlock()
 
+	c.writeQueue.DiscardPredicate(pred)
+
+	keys, err := c.engine.Keys()
+	if err != nil {
+		return err
+	}
+	for _, key := range keys {
+		if pred(key) {
+			if err := c.engine.Delete(key); err != nil {
+				return err
+			}
+		}
+	}
 	return nil
 }
 
-// DeleteWithPrefix removes all keys that start with given prefix, returns number of deleted keys
+// DeleteWithPrefix synchronously removes all keys that start with the given
+// prefix. Same fencing and error semantics as DeletePredicate.
 func (c *Cache[T]) DeleteWithPrefix(prefix string) error {
 	pred := func(s string) bool {
 		return strings.HasPrefix(s, prefix)
@@ -209,7 +250,8 @@ func (c *Cache[T]) DeleteWithPrefix(prefix string) error {
 	return c.DeletePredicate(pred)
 }
 
-// DeleteRegExp deletes all keys matching the supplied regexp, returns number of deleted keys
+// DeleteRegExp synchronously deletes all keys matching the supplied regexp.
+// Same fencing and error semantics as DeletePredicate.
 func (c *Cache[T]) DeleteRegExp(pattern string) error {
 	re, err := regexp.Compile(pattern)
 	if err != nil {
@@ -268,18 +310,31 @@ func (c *Cache[T]) Peek(key string) (*T, error) {
 	return assertCached[T](untypedValue)
 }
 
-// Delete removes a key from cache
+// Delete synchronously removes a key from the cache engine, discarding any
+// queued write for it first, and returns the engine's real error. It holds
+// the key's compute lock, so no compute for this key can be in flight
+// (GetOrCompute's write-back goroutine holds that lock until it finishes).
+// Nothing is retried on failure — the caller owns the retry decision.
 func (c *Cache[T]) Delete(key string) error {
 	mutex := c.computeLocks.Lock(key)
 	defer c.computeLocks.Unlock(key, mutex)
-	c.writeQueue.Delete(key) // Remove from write queue
-	return nil
+
+	c.engineMu.Lock()
+	defer c.engineMu.Unlock()
+
+	c.writeQueue.Discard(key)
+	return c.engine.Delete(key)
 }
 
-// Purge removes all records from the cache
+// Purge synchronously removes all records from the cache, discarding every
+// queued write and fencing every in-flight compute. Returns the engine's
+// real error; nothing is retried on failure.
 func (c *Cache[T]) Purge() error {
-	c.writeQueue.Purge() // Clear the write queue
-	return nil
+	c.engineMu.Lock()
+	defer c.engineMu.Unlock()
+
+	c.writeQueue.DiscardPredicate(func(string) bool { return true })
+	return c.engine.Purge()
 }
 
 // Keys returns all the keys in cache
@@ -323,9 +378,11 @@ func assertCached[T any](v interface{}) (*T, error) {
 	return nil, ErrWrongDataType
 }
 
-// setNoLock stores a key-value pair into cache
-func (c *Cache[T]) setNoLock(key string, value *T) error {
-	c.writeQueue.Set(key, value)
+// setNoLock stores a key-value pair into cache. A non-nil token fences the
+// write: it is skipped when the token was invalidated by a concurrent
+// invalidation (H4).
+func (c *Cache[T]) setNoLock(key string, value *T, token *computeToken) error {
+	c.writeQueue.TrySet(key, value, token)
 	return nil
 }
 
@@ -346,75 +403,46 @@ func (c *Cache[T]) getIndirectNoLock(key string, linkResolver func(*T) string) (
 	return value, nil
 }
 
-// setIndirectNoLock sets cache key including intermediary links
-func (c *Cache[T]) setIndirectNoLock(key string, value *T, linkResolver func(*T) string, linkGenerator func(*T) *T) error {
+// setIndirectNoLock sets cache key including intermediary links. The token
+// (fencing the compute registered for key, nil for unfenced writes) gates
+// each leaf write; a predicate matching only the derived link key marks no
+// token, so such writes are only caught while still queued — a pre-existing
+// granularity limit of the link feature.
+func (c *Cache[T]) setIndirectNoLock(key string, value *T, linkResolver func(*T) string, linkGenerator func(*T) *T, token *computeToken) error {
 	if linkGenerator != nil && linkResolver != nil {
 		if linkValue := linkGenerator(value); linkValue != nil {
 			link := linkResolver(linkValue)
 			if link != key {
 				lock := c.computeLocks.Lock(link)
 				defer c.computeLocks.Unlock(link, lock)
-				if err := c.setNoLock(key, linkValue); err != nil {
+				if err := c.setNoLock(key, linkValue, token); err != nil {
 					return err
 				}
 			}
 
-			return c.setNoLock(link, value)
+			return c.setNoLock(link, value, token)
 		}
 	}
 
-	return c.setNoLock(key, value)
+	return c.setNoLock(key, value, token)
 }
 
 // writeLoop is a goroutine that processes the write queue.
 func (c *Cache[T]) writeLoop() {
+	defer close(c.stopped)
 	var lastStatsTime time.Time
-	for range time.Tick(c.writeInterval) {
-		for {
-			op, ok := c.writeQueue.StartWriting()
-			if !ok {
-				break // No more items to process
+	for {
+		select {
+		case <-c.done:
+			// Best-effort final drain so a graceful shutdown does not
+			// strand queued writes.
+			for c.runOneWriteCycle() {
 			}
+			return
+		case <-c.ticker.C:
+		}
 
-			var err error
-
-			switch op := op.(type) {
-			case *queueOperationSet[T]:
-				err = c.engine.Set(op.Key, op.Value)
-
-				c.writeQueue.DoneWriting(err == nil)
-
-			case *queueOperationDelete:
-				err = c.engine.Delete(op.Key)
-
-				c.writeQueue.DoneWriting(err == nil)
-
-			case *queueOperationDeletePredicate:
-				var keys []string
-				keys, err = c.engine.Keys()
-				if err == nil {
-					for _, key := range keys {
-						if op.Predicate(key) {
-							err = c.engine.Delete(key)
-							if err != nil {
-								break
-							}
-						}
-					}
-				}
-
-				c.writeQueue.DoneWriting(err == nil)
-
-			case *queueOperationPurge:
-				err := c.engine.Purge()
-
-				c.writeQueue.DoneWriting(err == nil)
-			}
-
-			if err != nil {
-				c.logger.Print("write loop error: ", err.Error(), " for operation: ", op.String())
-				break
-			}
+		for c.runOneWriteCycle() {
 		}
 
 		if time.Since(lastStatsTime) >= c.statsInterval {
@@ -425,4 +453,58 @@ func (c *Cache[T]) writeLoop() {
 			}
 		}
 	}
+}
+
+// runOneWriteCycle processes at most one queued operation under engineMu,
+// so a whole StartWriting-engine-op-DoneWriting cycle is atomic relative to
+// the synchronous invalidations (which also run under engineMu); engineMu
+// is released between cycles so an invalidation never waits for a full
+// queue drain. Returns false when the caller should stop draining: the
+// queue is empty, or the op failed, stays at the front, and must wait for
+// the next tick instead of hot-spinning. Only Set ops are enqueued since
+// the invalidations became synchronous; the other cases are kept
+// defensively until the queue is simplified.
+func (c *Cache[T]) runOneWriteCycle() bool {
+	c.engineMu.Lock()
+	defer c.engineMu.Unlock()
+
+	op, ok := c.writeQueue.StartWriting()
+	if !ok {
+		return false // No more items to process
+	}
+
+	var err error
+
+	switch op := op.(type) {
+	case *queueOperationSet[T]:
+		err = c.engine.Set(op.Key, op.Value)
+
+	case *queueOperationDelete:
+		err = c.engine.Delete(op.Key)
+
+	case *queueOperationDeletePredicate:
+		var keys []string
+		keys, err = c.engine.Keys()
+		if err == nil {
+			for _, key := range keys {
+				if op.Predicate(key) {
+					err = c.engine.Delete(key)
+					if err != nil {
+						break
+					}
+				}
+			}
+		}
+
+	case *queueOperationPurge:
+		err = c.engine.Purge()
+	}
+
+	c.writeQueue.DoneWriting(err == nil)
+
+	if err != nil {
+		c.logger.Print("write loop error: ", err.Error(), " for operation: ", op.String())
+		return false
+	}
+	return true
 }

--- a/read_path_test.go
+++ b/read_path_test.go
@@ -51,13 +51,13 @@ func flushWriteQueue[T any](t *testing.T, c *Cache[T]) {
 			var keys []string
 			keys, err = c.engine.Keys()
 			if err == nil {
+				matching := make([]string, 0, len(keys))
 				for _, key := range keys {
 					if op.Predicate(key) {
-						if err = c.engine.Delete(key); err != nil {
-							break
-						}
+						matching = append(matching, key)
 					}
 				}
+				err = c.deleteKeys(matching)
 			}
 		case *queueOperationPurge:
 			err = c.engine.Purge()

--- a/read_path_test.go
+++ b/read_path_test.go
@@ -30,7 +30,10 @@ func newTestCache[T any](engine CacheEngine) *Cache[T] {
 }
 
 // flushWriteQueue synchronously drains all pending operations into the
-// engine, replicating one writeLoop pass.
+// engine, replicating one writeLoop pass. Its dispatch switch mirrors
+// Cache.runOneWriteCycle and must be updated in lockstep — it stays
+// separate because its failure contract differs (any engine error fails
+// the test loudly instead of yielding to the next tick).
 func flushWriteQueue[T any](t *testing.T, c *Cache[T]) {
 	t.Helper()
 	for {

--- a/redis.go
+++ b/redis.go
@@ -169,17 +169,30 @@ func (rc *RedisCache) Keys() ([]string, error) {
 	return keys, nil
 }
 
-// Purge removes all the records from the cache
-func (rc *RedisCache) Purge() error {
-	//FIXME: delete all keys from redis at once
-	keys, err := rc.Keys()
-	if err != nil {
-		return err
-	}
-	for _, key := range keys {
-		if err := rc.Delete(key); err != nil {
+// redisDeleteBatchSize bounds how many keys one UNLINK command carries.
+const redisDeleteBatchSize = 500
+
+// DeleteMany removes the given keys in batched UNLINK commands — one round
+// trip per batch instead of one per key.
+func (rc *RedisCache) DeleteMany(keys []string) error {
+	for start := 0; start < len(keys); start += redisDeleteBatchSize {
+		end := min(start+redisDeleteBatchSize, len(keys))
+		batch := make([]string, 0, end-start)
+		for _, key := range keys[start:end] {
+			batch = append(batch, rc.keyPrefix+key)
+		}
+		if err := rc.redisClient.Unlink(ctx, batch...).Err(); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// Purge removes all the records from the cache
+func (rc *RedisCache) Purge() error {
+	keys, err := rc.Keys()
+	if err != nil {
+		return err
+	}
+	return rc.DeleteMany(keys)
 }

--- a/redis.go
+++ b/redis.go
@@ -150,19 +150,23 @@ func (rc *RedisCache) Delete(key string) error {
 	return rc.redisClient.Del(ctx, rc.keyPrefix+key).Err()
 }
 
-// Keys returns all the keys in the cache
+// redisScanCount is the COUNT hint for SCAN iterations.
+const redisScanCount = 1000
+
+// Keys returns all the keys in the cache. It iterates with SCAN instead of
+// KEYS so a large keyspace does not block the redis server for the whole
+// enumeration.
 func (rc *RedisCache) Keys() ([]string, error) {
-	keys, err := rc.redisClient.Keys(ctx, rc.keyPrefix+"*").Result()
-	if err != nil {
+	keys := make([]string, 0)
+	iter := rc.redisClient.Scan(ctx, 0, rc.keyPrefix+"*", redisScanCount).Iterator()
+	for iter.Next(ctx) {
+		keys = append(keys, strings.TrimPrefix(iter.Val(), rc.keyPrefix))
+	}
+	if err := iter.Err(); err != nil {
 		return nil, err
 	}
 
-	strippedKeys := make([]string, 0, len(keys))
-	for _, key := range keys {
-		strippedKeys = append(strippedKeys, strings.TrimPrefix(key, rc.keyPrefix))
-	}
-
-	return strippedKeys, nil
+	return keys, nil
 }
 
 // Purge removes all the records from the cache

--- a/sync_invalidation_test.go
+++ b/sync_invalidation_test.go
@@ -135,25 +135,39 @@ func (l *recordingLogger) countContaining(sub string) int {
 	return count
 }
 
-// M12: invalidations must reach the engine synchronously — before the call
-// returns, not on a later write-loop tick — and must report the engine's
-// real error instead of unconditionally returning nil.
+// M12 (async form, decided 2026-07-08): invalidations never block on the
+// engine — they mask in-process reads immediately via the queued op, the
+// engine-side work happens on the write loop, and a failing engine op is
+// retried head-of-line until it succeeds.
 
-func TestDelete_SynchronouslyRemovesFromEngine(t *testing.T) {
+func TestDelete_MasksReadsImmediatelyAndRemovesOnFlush(t *testing.T) {
 	engine := newFakeEngine()
 	engine.seed("k", &testEntry{ID: 1})
 	c := newTestCache[testEntry](engine)
 
 	require.NoError(t, c.Delete("k"))
-	assert.False(t, engine.has("k"), "Delete must remove the key from the engine before returning, not on a later flush")
+	_, err := c.Get("k")
+	assert.ErrorIs(t, err, ErrNotFound, "reads must see the deletion before the flush")
+	assert.True(t, engine.has("k"), "the engine delete is deferred to the write loop")
+
+	flushWriteQueue(t, c)
+	assert.False(t, engine.has("k"), "the flush must remove the key from the engine")
 }
 
-func TestDelete_ReturnsEngineError(t *testing.T) {
+func TestDelete_FailedEngineDeleteRetriesUntilRecovery(t *testing.T) {
 	engine := newFakeEngine()
+	engine.seed("k", &testEntry{ID: 1})
 	engine.deleteErr = errEngineBoom
 	c := newTestCache[testEntry](engine)
 
-	assert.ErrorIs(t, c.Delete("k"), errEngineBoom)
+	require.NoError(t, c.Delete("k"), "Delete reports nil by design; failures are the write loop's to retry")
+
+	assert.False(t, c.runOneWriteCycle(), "the failing delete stops the drain")
+	assert.True(t, engine.has("k"))
+
+	engine.deleteErr = nil
+	assert.True(t, c.runOneWriteCycle(), "the op stays at the front and succeeds once the engine recovers")
+	assert.False(t, engine.has("k"))
 }
 
 func TestDelete_DiscardsPendingSet(t *testing.T) {
@@ -169,7 +183,7 @@ func TestDelete_DiscardsPendingSet(t *testing.T) {
 	assert.ErrorIs(t, err, ErrNotFound)
 }
 
-func TestDeletePredicate_SynchronouslyRemovesMatchingEngineKeys(t *testing.T) {
+func TestDeletePredicate_MasksReadsImmediatelyAndRemovesOnFlush(t *testing.T) {
 	engine := newFakeEngine()
 	engine.seed("a:1", &testEntry{ID: 1})
 	engine.seed("a:2", &testEntry{ID: 2})
@@ -177,45 +191,50 @@ func TestDeletePredicate_SynchronouslyRemovesMatchingEngineKeys(t *testing.T) {
 	c := newTestCache[testEntry](engine)
 
 	require.NoError(t, c.DeleteWithPrefix("a:"))
-	assert.False(t, engine.has("a:1"), "matching keys must be gone from the engine when the call returns")
-	assert.False(t, engine.has("a:2"), "matching keys must be gone from the engine when the call returns")
+	_, err := c.Get("a:1")
+	assert.ErrorIs(t, err, ErrNotFound, "reads must see the predicate deletion before the flush")
+	got, err := c.Get("b:1")
+	require.NoError(t, err, "non-matching keys must stay readable")
+	assert.Equal(t, testEntry{ID: 3}, *got)
+	assert.True(t, engine.has("a:1"), "the engine delete is deferred to the write loop")
+
+	flushWriteQueue(t, c)
+	assert.False(t, engine.has("a:1"), "matching keys must be gone after the flush")
+	assert.False(t, engine.has("a:2"), "matching keys must be gone after the flush")
 	assert.True(t, engine.has("b:1"), "non-matching keys must survive")
 }
 
-func TestDeletePredicate_ReturnsEngineKeysError(t *testing.T) {
+func TestDeletePredicate_EngineFailureRetriesUntilRecovery(t *testing.T) {
 	engine := newFakeEngine()
+	engine.seed("k", &testEntry{ID: 1})
 	engine.keysErr = errEngineBoom
 	c := newTestCache[testEntry](engine)
 
-	assert.ErrorIs(t, c.DeletePredicate(func(string) bool { return true }), errEngineBoom)
+	require.NoError(t, c.DeletePredicate(func(string) bool { return true }), "DeletePredicate reports nil by design")
+
+	assert.False(t, c.runOneWriteCycle(), "the failing enumeration stops the drain")
+	assert.False(t, c.runOneWriteCycle(), "the op stays at the front while the engine is down")
+	assert.True(t, engine.has("k"))
+
+	engine.keysErr = nil
+	assert.True(t, c.runOneWriteCycle(), "the retry succeeds once the engine recovers")
+	assert.False(t, engine.has("k"))
 }
 
-func TestDeletePredicate_ReturnsEngineDeleteError(t *testing.T) {
-	engine := newFakeEngine()
-	engine.seed("k", &testEntry{ID: 1})
-	engine.deleteErr = errEngineBoom
-	c := newTestCache[testEntry](engine)
-
-	assert.ErrorIs(t, c.DeletePredicate(func(string) bool { return true }), errEngineBoom)
-}
-
-func TestPurge_SynchronouslyClearsEngine(t *testing.T) {
+func TestPurge_MasksReadsImmediatelyAndClearsOnFlush(t *testing.T) {
 	engine := newFakeEngine()
 	engine.seed("k1", &testEntry{ID: 1})
 	engine.seed("k2", &testEntry{ID: 2})
 	c := newTestCache[testEntry](engine)
 
 	require.NoError(t, c.Purge())
-	assert.False(t, engine.has("k1"), "Purge must clear the engine before returning")
-	assert.False(t, engine.has("k2"), "Purge must clear the engine before returning")
-}
+	_, err := c.Get("k1")
+	assert.ErrorIs(t, err, ErrNotFound, "reads must see the purge before the flush")
+	assert.True(t, engine.has("k1"), "the engine purge is deferred to the write loop")
 
-func TestPurge_ReturnsEngineError(t *testing.T) {
-	engine := newFakeEngine()
-	engine.purgeErr = errEngineBoom
-	c := newTestCache[testEntry](engine)
-
-	assert.ErrorIs(t, c.Purge(), errEngineBoom)
+	flushWriteQueue(t, c)
+	assert.False(t, engine.has("k1"), "the engine must be cleared after the flush")
+	assert.False(t, engine.has("k2"), "the engine must be cleared after the flush")
 }
 
 func TestPurge_DiscardsPendingSets(t *testing.T) {
@@ -231,11 +250,11 @@ func TestPurge_DiscardsPendingSets(t *testing.T) {
 	assert.ErrorIs(t, err, ErrNotFound)
 }
 
-// M12 ordering: a synchronous invalidation must not interleave with an
-// in-flight write-loop engine op — it lands strictly after, so the key is
-// absent once both complete.
+// Ordering: an invalidation issued while an engine write is in flight must
+// not block the caller, and FIFO puts its queued op behind the in-flight
+// Set — so once both flush, the key is absent.
 
-func TestDeletePredicate_WaitsForInFlightEngineWrite(t *testing.T) {
+func TestDeletePredicate_DoesNotBlockOnInFlightEngineWrite(t *testing.T) {
 	engine := newFakeEngine()
 	setStarted := make(chan struct{})
 	setRelease := make(chan struct{})
@@ -256,14 +275,15 @@ func TestDeletePredicate_WaitsForInFlightEngineWrite(t *testing.T) {
 	go func() { done <- c.DeletePredicate(func(string) bool { return true }) }()
 
 	select {
-	case <-done:
-		t.Fatal("DeletePredicate returned while an engine write for a matching key was still in flight")
-	case <-time.After(100 * time.Millisecond):
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("DeletePredicate must not block on an in-flight engine write")
 	}
 
 	release()
-	require.NoError(t, <-done)
-	assert.False(t, engine.has("k"), "the predicate delete must land after the in-flight write, leaving the key absent")
+	assert.Eventually(t, func() bool { return !engine.has("k") }, 5*time.Second, 50*time.Millisecond,
+		"the queued predicate delete lands after the in-flight write, leaving the key absent")
 }
 
 // M10: a queued purge that keeps failing must be attempted once per tick —
@@ -277,9 +297,7 @@ func TestWriteLoop_FailingPurgeYieldsToNextTick(t *testing.T) {
 	c := MakeCache[testEntry](engine, logger)
 	t.Cleanup(c.Close)
 
-	// Seed the queue directly: after M12, Cache.Purge is synchronous and
-	// never enqueues, but the write loop must still handle a queued purge.
-	c.writeQueue.Purge()
+	require.NoError(t, c.Purge())
 
 	time.Sleep(2500 * time.Millisecond)
 
@@ -301,7 +319,7 @@ func TestRunOneWriteCycle_FailingOpStopsDrain(t *testing.T) {
 	c := newTestCache[testEntry](engine)
 	c.logger = logger
 
-	c.writeQueue.Purge()
+	require.NoError(t, c.Purge())
 
 	assert.False(t, c.runOneWriteCycle(), "a failing op must stop the drain")
 	assert.Equal(t, int32(1), engine.purgeCalls.Load(), "exactly one attempt per cycle")
@@ -310,8 +328,9 @@ func TestRunOneWriteCycle_FailingOpStopsDrain(t *testing.T) {
 	assert.Equal(t, 2, logger.countContaining("write loop error"), "every failed attempt must be logged")
 }
 
-// Close: stops the write loop after one final drain, idempotent, and the
-// synchronous invalidations keep working afterwards.
+// Close: stops the write loop after one final drain, idempotent. Writes
+// and invalidations enqueued after Close never reach the engine (they only
+// mask in-process reads) — the documented contract.
 
 func TestClose_StopsWriteLoopAndDrains(t *testing.T) {
 	engine := newFakeEngine()
@@ -322,7 +341,9 @@ func TestClose_StopsWriteLoopAndDrains(t *testing.T) {
 	assert.True(t, engine.has("k"), "Close must drain queued writes before stopping")
 
 	require.NoError(t, c.Delete("k"))
-	assert.False(t, engine.has("k"), "synchronous invalidations must keep working after Close")
+	_, err := c.Get("k")
+	assert.ErrorIs(t, err, ErrNotFound, "a post-Close invalidation still masks in-process reads")
+	assert.True(t, engine.has("k"), "a post-Close invalidation never reaches the engine — stop invalidating before Close")
 
 	require.NoError(t, c.Set("later", &testEntry{ID: 2}))
 	time.Sleep(1200 * time.Millisecond)
@@ -350,4 +371,61 @@ func TestRedisKeys_ScanRespectsPrefix(t *testing.T) {
 	keys, err := rc.Keys()
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []string{"a", "b"}, keys)
+}
+
+// bulkFakeEngine is fakeEngine plus a recording BulkDeleter fast path.
+type bulkFakeEngine struct {
+	*fakeEngine
+	manyMu    sync.Mutex
+	manyCalls [][]string
+}
+
+func (b *bulkFakeEngine) DeleteMany(keys []string) error {
+	b.manyMu.Lock()
+	b.manyCalls = append(b.manyCalls, append([]string(nil), keys...))
+	b.manyMu.Unlock()
+	for _, key := range keys {
+		if err := b.fakeEngine.Delete(key); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func TestPredicateFlushUsesBulkDeleter(t *testing.T) {
+	engine := &bulkFakeEngine{fakeEngine: newFakeEngine()}
+	engine.seed("a:1", &testEntry{ID: 1})
+	engine.seed("a:2", &testEntry{ID: 2})
+	engine.seed("b:1", &testEntry{ID: 3})
+	c := newTestCache[testEntry](engine)
+
+	require.NoError(t, c.DeleteWithPrefix("a:"))
+	flushWriteQueue(t, c)
+
+	require.Len(t, engine.manyCalls, 1, "the flush must use the engine's bulk fast path, not per-key deletes")
+	assert.ElementsMatch(t, []string{"a:1", "a:2"}, engine.manyCalls[0])
+	assert.False(t, engine.has("a:1"))
+	assert.True(t, engine.has("b:1"))
+}
+
+// RedisCache.Purge and DeleteMany remove keys in batched UNLINKs (one round
+// trip per redisDeleteBatchSize keys) instead of one DEL per key.
+
+func TestRedisPurge_BatchedUnlinkClearsLargeKeyspace(t *testing.T) {
+	server := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: server.Addr()})
+	rc := NewRedisCache(client, "pfx:", jsonMarshal, valueUnmarshal, 0, nil)
+
+	const n = 1100 // spans multiple UNLINK batches
+	for i := 0; i < n; i++ {
+		require.NoError(t, rc.Set(fmt.Sprintf("k%d", i), &testEntry{ID: i}))
+	}
+	require.NoError(t, server.Set("other:c", "x")) // outside the prefix
+
+	require.NoError(t, rc.Purge())
+
+	keys, err := rc.Keys()
+	require.NoError(t, err)
+	assert.Empty(t, keys, "all prefixed keys must be gone")
+	assert.True(t, server.Exists("other:c"), "keys outside the prefix must survive")
 }

--- a/sync_invalidation_test.go
+++ b/sync_invalidation_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -283,4 +285,65 @@ func TestWriteLoop_FailingPurgeYieldsToNextTick(t *testing.T) {
 	assert.GreaterOrEqual(t, calls, int32(1), "the queued purge must be attempted")
 	assert.LessOrEqual(t, calls, int32(3), "a failing purge must be retried once per tick, not hot-spun within one tick")
 	assert.NotZero(t, logger.countContaining("write loop error"), "the purge failure must be logged")
+}
+
+// Deterministic companion to the tick-based M10 test: one cycle = one
+// attempt, the failing op stays at the front for the next cycle.
+
+func TestRunOneWriteCycle_FailingOpStopsDrain(t *testing.T) {
+	engine := newFakeEngine()
+	engine.purgeErr = errEngineBoom
+	logger := &recordingLogger{}
+	c := newTestCache[testEntry](engine)
+	c.logger = logger
+
+	c.writeQueue.Purge()
+
+	assert.False(t, c.runOneWriteCycle(), "a failing op must stop the drain")
+	assert.Equal(t, int32(1), engine.purgeCalls.Load(), "exactly one attempt per cycle")
+	assert.False(t, c.runOneWriteCycle(), "the op stays at the front and is retried on the next cycle")
+	assert.Equal(t, int32(2), engine.purgeCalls.Load())
+	assert.Equal(t, 2, logger.countContaining("write loop error"), "every failed attempt must be logged")
+}
+
+// Close: stops the write loop after one final drain, idempotent, and the
+// synchronous invalidations keep working afterwards.
+
+func TestClose_StopsWriteLoopAndDrains(t *testing.T) {
+	engine := newFakeEngine()
+	c := MakeCache[testEntry](engine, DummyLogger{})
+
+	require.NoError(t, c.Set("k", &testEntry{ID: 1}))
+	c.Close()
+	assert.True(t, engine.has("k"), "Close must drain queued writes before stopping")
+
+	require.NoError(t, c.Delete("k"))
+	assert.False(t, engine.has("k"), "synchronous invalidations must keep working after Close")
+
+	require.NoError(t, c.Set("later", &testEntry{ID: 2}))
+	time.Sleep(1200 * time.Millisecond)
+	assert.False(t, engine.has("later"), "no write loop may flush writes enqueued after Close")
+}
+
+func TestClose_Idempotent(t *testing.T) {
+	c := MakeCache[testEntry](newFakeEngine(), DummyLogger{})
+	c.Close()
+	c.Close() // must not panic or block
+}
+
+// RedisCache.Keys iterates with SCAN; behavior must match the old KEYS
+// implementation: all prefixed keys, stripped, nothing else.
+
+func TestRedisKeys_ScanRespectsPrefix(t *testing.T) {
+	server := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: server.Addr()})
+	rc := NewRedisCache(client, "pfx:", jsonMarshal, valueUnmarshal, 0, nil)
+
+	require.NoError(t, rc.Set("a", &testEntry{ID: 1}))
+	require.NoError(t, rc.Set("b", &testEntry{ID: 2}))
+	require.NoError(t, server.Set("other:c", "x")) // outside the prefix
+
+	keys, err := rc.Keys()
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"a", "b"}, keys)
 }

--- a/sync_invalidation_test.go
+++ b/sync_invalidation_test.go
@@ -247,6 +247,7 @@ func TestDeletePredicate_WaitsForInFlightEngineWrite(t *testing.T) {
 		<-setRelease
 	}
 	c := MakeCache[testEntry](engine, DummyLogger{})
+	t.Cleanup(c.Close)
 
 	require.NoError(t, c.Set("k", &testEntry{ID: 1}))
 	<-setStarted // the write loop is now blocked inside engine.Set("k")
@@ -274,6 +275,7 @@ func TestWriteLoop_FailingPurgeYieldsToNextTick(t *testing.T) {
 	engine.purgeErr = errEngineBoom
 	logger := &recordingLogger{}
 	c := MakeCache[testEntry](engine, logger)
+	t.Cleanup(c.Close)
 
 	// Seed the queue directly: after M12, Cache.Purge is synchronous and
 	// never enqueues, but the write loop must still handle a queued purge.
@@ -281,9 +283,11 @@ func TestWriteLoop_FailingPurgeYieldsToNextTick(t *testing.T) {
 
 	time.Sleep(2500 * time.Millisecond)
 
+	// The generous upper bound absorbs tick catch-up after CI scheduler
+	// stalls; a hot-spinning loop produces millions of calls in this window.
 	calls := engine.purgeCalls.Load()
 	assert.GreaterOrEqual(t, calls, int32(1), "the queued purge must be attempted")
-	assert.LessOrEqual(t, calls, int32(3), "a failing purge must be retried once per tick, not hot-spun within one tick")
+	assert.LessOrEqual(t, calls, int32(5), "a failing purge must be retried once per tick, not hot-spun within one tick")
 	assert.NotZero(t, logger.countContaining("write loop error"), "the purge failure must be logged")
 }
 

--- a/sync_invalidation_test.go
+++ b/sync_invalidation_test.go
@@ -1,0 +1,286 @@
+package cachier
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var errEngineBoom = errors.New("engine boom")
+
+// fakeEngine is an instrumented in-memory CacheEngine: each method's error
+// is injectable and Set can be gated on a channel, so tests can provoke
+// exact orderings between the write loop and synchronous invalidations.
+type fakeEngine struct {
+	mu    sync.Mutex
+	store map[string]interface{}
+
+	onSet func(key string) // runs synchronously inside Set, before storing
+
+	deleteErr error
+	keysErr   error
+	purgeErr  error
+
+	purgeCalls atomic.Int32
+}
+
+func newFakeEngine() *fakeEngine {
+	return &fakeEngine{store: make(map[string]interface{})}
+}
+
+func (f *fakeEngine) Get(key string) (interface{}, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if v, ok := f.store[key]; ok {
+		return v, nil
+	}
+	return nil, ErrNotFound
+}
+
+func (f *fakeEngine) Peek(key string) (interface{}, error) {
+	return f.Get(key)
+}
+
+func (f *fakeEngine) Set(key string, value interface{}) error {
+	if f.onSet != nil {
+		f.onSet(key)
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.store[key] = value
+	return nil
+}
+
+func (f *fakeEngine) Delete(key string) error {
+	if f.deleteErr != nil {
+		return f.deleteErr
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.store, key)
+	return nil
+}
+
+func (f *fakeEngine) Keys() ([]string, error) {
+	if f.keysErr != nil {
+		return nil, f.keysErr
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	keys := make([]string, 0, len(f.store))
+	for k := range f.store {
+		keys = append(keys, k)
+	}
+	return keys, nil
+}
+
+func (f *fakeEngine) Purge() error {
+	f.purgeCalls.Add(1)
+	if f.purgeErr != nil {
+		return f.purgeErr
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.store = make(map[string]interface{})
+	return nil
+}
+
+func (f *fakeEngine) has(key string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	_, ok := f.store[key]
+	return ok
+}
+
+func (f *fakeEngine) seed(key string, value *testEntry) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.store[key] = value
+}
+
+// recordingLogger captures log lines so tests can assert on them.
+type recordingLogger struct {
+	mu    sync.Mutex
+	lines []string
+}
+
+func (l *recordingLogger) log(args ...interface{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.lines = append(l.lines, fmt.Sprint(args...))
+}
+
+func (l *recordingLogger) Error(args ...interface{}) { l.log(args...) }
+func (l *recordingLogger) Warn(args ...interface{})  { l.log(args...) }
+func (l *recordingLogger) Print(args ...interface{}) { l.log(args...) }
+
+func (l *recordingLogger) countContaining(sub string) int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	count := 0
+	for _, line := range l.lines {
+		if strings.Contains(line, sub) {
+			count++
+		}
+	}
+	return count
+}
+
+// M12: invalidations must reach the engine synchronously — before the call
+// returns, not on a later write-loop tick — and must report the engine's
+// real error instead of unconditionally returning nil.
+
+func TestDelete_SynchronouslyRemovesFromEngine(t *testing.T) {
+	engine := newFakeEngine()
+	engine.seed("k", &testEntry{ID: 1})
+	c := newTestCache[testEntry](engine)
+
+	require.NoError(t, c.Delete("k"))
+	assert.False(t, engine.has("k"), "Delete must remove the key from the engine before returning, not on a later flush")
+}
+
+func TestDelete_ReturnsEngineError(t *testing.T) {
+	engine := newFakeEngine()
+	engine.deleteErr = errEngineBoom
+	c := newTestCache[testEntry](engine)
+
+	assert.ErrorIs(t, c.Delete("k"), errEngineBoom)
+}
+
+func TestDelete_DiscardsPendingSet(t *testing.T) {
+	engine := newFakeEngine()
+	c := newTestCache[testEntry](engine)
+
+	require.NoError(t, c.Set("k", &testEntry{ID: 1}))
+	require.NoError(t, c.Delete("k"))
+
+	flushWriteQueue(t, c)
+	assert.False(t, engine.has("k"), "a Set queued before Delete must never reach the engine")
+	_, err := c.Get("k")
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestDeletePredicate_SynchronouslyRemovesMatchingEngineKeys(t *testing.T) {
+	engine := newFakeEngine()
+	engine.seed("a:1", &testEntry{ID: 1})
+	engine.seed("a:2", &testEntry{ID: 2})
+	engine.seed("b:1", &testEntry{ID: 3})
+	c := newTestCache[testEntry](engine)
+
+	require.NoError(t, c.DeleteWithPrefix("a:"))
+	assert.False(t, engine.has("a:1"), "matching keys must be gone from the engine when the call returns")
+	assert.False(t, engine.has("a:2"), "matching keys must be gone from the engine when the call returns")
+	assert.True(t, engine.has("b:1"), "non-matching keys must survive")
+}
+
+func TestDeletePredicate_ReturnsEngineKeysError(t *testing.T) {
+	engine := newFakeEngine()
+	engine.keysErr = errEngineBoom
+	c := newTestCache[testEntry](engine)
+
+	assert.ErrorIs(t, c.DeletePredicate(func(string) bool { return true }), errEngineBoom)
+}
+
+func TestDeletePredicate_ReturnsEngineDeleteError(t *testing.T) {
+	engine := newFakeEngine()
+	engine.seed("k", &testEntry{ID: 1})
+	engine.deleteErr = errEngineBoom
+	c := newTestCache[testEntry](engine)
+
+	assert.ErrorIs(t, c.DeletePredicate(func(string) bool { return true }), errEngineBoom)
+}
+
+func TestPurge_SynchronouslyClearsEngine(t *testing.T) {
+	engine := newFakeEngine()
+	engine.seed("k1", &testEntry{ID: 1})
+	engine.seed("k2", &testEntry{ID: 2})
+	c := newTestCache[testEntry](engine)
+
+	require.NoError(t, c.Purge())
+	assert.False(t, engine.has("k1"), "Purge must clear the engine before returning")
+	assert.False(t, engine.has("k2"), "Purge must clear the engine before returning")
+}
+
+func TestPurge_ReturnsEngineError(t *testing.T) {
+	engine := newFakeEngine()
+	engine.purgeErr = errEngineBoom
+	c := newTestCache[testEntry](engine)
+
+	assert.ErrorIs(t, c.Purge(), errEngineBoom)
+}
+
+func TestPurge_DiscardsPendingSets(t *testing.T) {
+	engine := newFakeEngine()
+	c := newTestCache[testEntry](engine)
+
+	require.NoError(t, c.Set("k", &testEntry{ID: 1}))
+	require.NoError(t, c.Purge())
+
+	flushWriteQueue(t, c)
+	assert.False(t, engine.has("k"), "a Set queued before Purge must never reach the engine")
+	_, err := c.Get("k")
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+// M12 ordering: a synchronous invalidation must not interleave with an
+// in-flight write-loop engine op — it lands strictly after, so the key is
+// absent once both complete.
+
+func TestDeletePredicate_WaitsForInFlightEngineWrite(t *testing.T) {
+	engine := newFakeEngine()
+	setStarted := make(chan struct{})
+	setRelease := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(setRelease) }) }
+	defer release()
+	engine.onSet = func(string) {
+		close(setStarted)
+		<-setRelease
+	}
+	c := MakeCache[testEntry](engine, DummyLogger{})
+
+	require.NoError(t, c.Set("k", &testEntry{ID: 1}))
+	<-setStarted // the write loop is now blocked inside engine.Set("k")
+
+	done := make(chan error, 1)
+	go func() { done <- c.DeletePredicate(func(string) bool { return true }) }()
+
+	select {
+	case <-done:
+		t.Fatal("DeletePredicate returned while an engine write for a matching key was still in flight")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	release()
+	require.NoError(t, <-done)
+	assert.False(t, engine.has("k"), "the predicate delete must land after the in-flight write, leaving the key absent")
+}
+
+// M10: a queued purge that keeps failing must be attempted once per tick —
+// logged, then yielding to the next tick — instead of hot-spinning silently
+// inside a single tick.
+
+func TestWriteLoop_FailingPurgeYieldsToNextTick(t *testing.T) {
+	engine := newFakeEngine()
+	engine.purgeErr = errEngineBoom
+	logger := &recordingLogger{}
+	c := MakeCache[testEntry](engine, logger)
+
+	// Seed the queue directly: after M12, Cache.Purge is synchronous and
+	// never enqueues, but the write loop must still handle a queued purge.
+	c.writeQueue.Purge()
+
+	time.Sleep(2500 * time.Millisecond)
+
+	calls := engine.purgeCalls.Load()
+	assert.GreaterOrEqual(t, calls, int32(1), "the queued purge must be attempted")
+	assert.LessOrEqual(t, calls, int32(3), "a failing purge must be retried once per tick, not hot-spun within one tick")
+	assert.NotZero(t, logger.countContaining("write loop error"), "the purge failure must be logged")
+}

--- a/write_queue.go
+++ b/write_queue.go
@@ -213,7 +213,9 @@ func (q *writeQueue[T]) TrySet(key string, value *T, token *computeToken) bool {
 }
 
 // RegisterToken creates the active compute token for key. Callers must hold
-// key's compute lock, which guarantees at most one live token per key.
+// key's compute lock from before RegisterToken until after DeregisterToken
+// — that discipline is what guarantees at most one live token per key, so a
+// new registration never overwrites a token another compute still holds.
 func (q *writeQueue[T]) RegisterToken(key string) *computeToken {
 	q.Lock()
 	defer q.Unlock()
@@ -223,9 +225,10 @@ func (q *writeQueue[T]) RegisterToken(key string) *computeToken {
 	return token
 }
 
-// DeregisterToken removes key's token once its compute has finished. The
-// identity check keeps a stale caller from ever removing a newer compute's
-// token.
+// DeregisterToken removes key's token once its compute has finished. Must
+// run before the caller releases key's compute lock (see RegisterToken);
+// the identity check additionally keeps a stale caller from ever removing
+// a newer compute's token should that discipline ever be broken.
 func (q *writeQueue[T]) DeregisterToken(key string, token *computeToken) {
 	q.Lock()
 	defer q.Unlock()

--- a/write_queue.go
+++ b/write_queue.go
@@ -131,9 +131,11 @@ func (o *queueOperationPurge) IncludesKey(key string) bool {
 // invalidations that run without that key's compute lock (DeletePredicate,
 // DeleteWithPrefix, DeleteRegExp, Purge). The invalidated flag is read and
 // written ONLY under the owning writeQueue's mutex: checking it and
-// enqueueing the write happen in one critical section (TrySet), as do
-// marking it and discarding queued writes (Discard/DiscardPredicate), so a
-// stale write can neither slip in after a discard nor dodge the mark.
+// enqueueing the write happen in one critical section (TrySet), as does
+// marking it while the invalidation op is enqueued (Delete/DeletePredicate/
+// Purge), so a fenced compute's write can neither be enqueued after the
+// invalidation nor dodge the mark; writes already queued are handled by
+// removeOverridden and FIFO ordering behind the invalidation op.
 type computeToken struct {
 	invalidated bool
 }
@@ -238,47 +240,8 @@ func (q *writeQueue[T]) DeregisterToken(key string, token *computeToken) {
 	}
 }
 
-// Discard removes any queued Set for key without queueing a delete op (the
-// caller deletes from the engine synchronously) and marks key's in-flight
-// compute token, if any, so its pending write-back is skipped. Callers run
-// under engineMu, so no write cycle is in flight (CurrentlyWriting is nil)
-// while the queue is swept.
-func (q *writeQueue[T]) Discard(key string) {
-	q.discardMatching(func(k string) bool { return k == key })
-}
-
-// DiscardPredicate removes every queued Set whose key matches pred and
-// marks every matching in-flight compute token. Same engineMu caveat as
-// Discard.
-func (q *writeQueue[T]) DiscardPredicate(pred Predicate) {
-	q.discardMatching(pred)
-}
-
-func (q *writeQueue[T]) discardMatching(pred Predicate) {
-	q.Lock()
-	defer q.Unlock()
-
-	i := 0
-	for i < q.Queue.Len() {
-		if op, ok := q.Queue.At(i).(*queueOperationSet[T]); ok && pred(op.Key) {
-			q.Queue.Remove(i)
-		} else {
-			i++
-		}
-	}
-	for key := range q.Values {
-		if pred(key) {
-			delete(q.Values, key)
-		}
-	}
-	for key, token := range q.tokens {
-		if pred(key) {
-			token.invalidated = true
-		}
-	}
-}
-
-// Delete queues a key for deletion
+// Delete queues a key for deletion and marks the key's in-flight compute
+// token, if any, so its pending write-back is skipped
 func (q *writeQueue[T]) Delete(key string) {
 	q.Lock()
 	defer q.Unlock()
@@ -288,9 +251,13 @@ func (q *writeQueue[T]) Delete(key string) {
 	q.Queue.PushBack(op)
 
 	delete(q.Values, key)
+	if token, ok := q.tokens[key]; ok {
+		token.invalidated = true
+	}
 }
 
-// DeletePredicate queues a deletion of all keys matching the supplied predicate
+// DeletePredicate queues a deletion of all keys matching the supplied
+// predicate and marks every matching in-flight compute token
 func (q *writeQueue[T]) DeletePredicate(pred Predicate) {
 	q.Lock()
 	defer q.Unlock()
@@ -302,6 +269,11 @@ func (q *writeQueue[T]) DeletePredicate(pred Predicate) {
 	for key := range q.Values {
 		if pred(key) {
 			delete(q.Values, key)
+		}
+	}
+	for key, token := range q.tokens {
+		if pred(key) {
+			token.invalidated = true
 		}
 	}
 }
@@ -329,7 +301,8 @@ func (q *writeQueue[T]) CountPredicate(pred Predicate) int {
 	return count // Return the total count
 }
 
-// Purge removes all records from the queue
+// Purge removes all records from the queue and marks every in-flight
+// compute token
 func (q *writeQueue[T]) Purge() {
 	q.Lock()
 	defer q.Unlock()
@@ -339,6 +312,9 @@ func (q *writeQueue[T]) Purge() {
 	q.Queue.PushBack(op)
 
 	q.Values = make(map[string]*T) // Reset the values map
+	for _, token := range q.tokens {
+		token.invalidated = true
+	}
 }
 
 // Keys returns all the keys in the queue

--- a/write_queue.go
+++ b/write_queue.go
@@ -127,11 +127,23 @@ func (o *queueOperationPurge) IncludesKey(key string) bool {
 	return true
 }
 
+// computeToken fences one in-flight GetOrCompute(Ex) call against
+// invalidations that run without that key's compute lock (DeletePredicate,
+// DeleteWithPrefix, DeleteRegExp, Purge). The invalidated flag is read and
+// written ONLY under the owning writeQueue's mutex: checking it and
+// enqueueing the write happen in one critical section (TrySet), as do
+// marking it and discarding queued writes (Discard/DiscardPredicate), so a
+// stale write can neither slip in after a discard nor dodge the mark.
+type computeToken struct {
+	invalidated bool
+}
+
 type writeQueue[T any] struct {
 	sync.Mutex
 	Queue            deque.Deque[queueOperation] // Queue to hold write cache operations
 	Values           map[string]*T               // Map to hold currently valid values that were not yet written
 	CurrentlyWriting queueOperation              // Queue write operation that is currently being processed
+	tokens           map[string]*computeToken    // Active compute tokens by key (H4 fencing)
 }
 
 // newWriteQueue creates a new CircularQueue with the specified size
@@ -139,6 +151,7 @@ func newWriteQueue[T any]() *writeQueue[T] {
 	return &writeQueue[T]{
 		Values:           make(map[string]*T),
 		CurrentlyWriting: nil,
+		tokens:           make(map[string]*computeToken),
 	}
 }
 
@@ -177,14 +190,89 @@ func (q *writeQueue[T]) Get(key string) (*T, bool) {
 
 // Set adds a new key-value pair to the queue
 func (q *writeQueue[T]) Set(key string, value *T) {
+	q.TrySet(key, value, nil)
+}
+
+// TrySet stores a key-value pair like Set unless the supplied token was
+// invalidated by a concurrent Discard/DiscardPredicate. A nil token is
+// never invalidated. Reports whether the value was stored.
+func (q *writeQueue[T]) TrySet(key string, value *T, token *computeToken) bool {
 	q.Lock()
 	defer q.Unlock()
+
+	if token != nil && token.invalidated {
+		return false
+	}
 
 	op := &queueOperationSet[T]{Key: key, Value: value}
 	q.removeOverridden(op)
 	q.Queue.PushBack(op)
 
 	q.Values[key] = value
+	return true
+}
+
+// RegisterToken creates the active compute token for key. Callers must hold
+// key's compute lock, which guarantees at most one live token per key.
+func (q *writeQueue[T]) RegisterToken(key string) *computeToken {
+	q.Lock()
+	defer q.Unlock()
+
+	token := &computeToken{}
+	q.tokens[key] = token
+	return token
+}
+
+// DeregisterToken removes key's token once its compute has finished. The
+// identity check keeps a stale caller from ever removing a newer compute's
+// token.
+func (q *writeQueue[T]) DeregisterToken(key string, token *computeToken) {
+	q.Lock()
+	defer q.Unlock()
+
+	if q.tokens[key] == token {
+		delete(q.tokens, key)
+	}
+}
+
+// Discard removes any queued Set for key without queueing a delete op (the
+// caller deletes from the engine synchronously) and marks key's in-flight
+// compute token, if any, so its pending write-back is skipped. Callers run
+// under engineMu, so no write cycle is in flight (CurrentlyWriting is nil)
+// while the queue is swept.
+func (q *writeQueue[T]) Discard(key string) {
+	q.discardMatching(func(k string) bool { return k == key })
+}
+
+// DiscardPredicate removes every queued Set whose key matches pred and
+// marks every matching in-flight compute token. Same engineMu caveat as
+// Discard.
+func (q *writeQueue[T]) DiscardPredicate(pred Predicate) {
+	q.discardMatching(pred)
+}
+
+func (q *writeQueue[T]) discardMatching(pred Predicate) {
+	q.Lock()
+	defer q.Unlock()
+
+	i := 0
+	for i < q.Queue.Len() {
+		if op, ok := q.Queue.At(i).(*queueOperationSet[T]); ok && pred(op.Key) {
+			q.Queue.Remove(i)
+		} else {
+			i++
+		}
+	}
+	for key := range q.Values {
+		if pred(key) {
+			delete(q.Values, key)
+		}
+	}
+	for key, token := range q.tokens {
+		if pred(key) {
+			token.invalidated = true
+		}
+	}
 }
 
 // Delete queues a key for deletion


### PR DESCRIPTION
Implements PR 10 of the g2 cache remediation plan (findings H4, M12, M10 from the 2026-07-02 audit), plus the resolved Q3 (SCAN) and Q12 (Close) decisions.

> **Design pivot (2026-07-08):** the first iteration made invalidations synchronous (inline engine work, real error returns — see the earlier commits). With ~200k records in prod redis, the inline SCAN+DEL per predicate delete (and minutes-scale Purge) was unacceptable caller latency on the dataset event listener, HTTP handlers and the live query path, so the owner redirected to **uniform async invalidation with fencing**. This supersedes the plan's Q2 pure-error decision.

## What changed

**H4 — per-key compute-token fencing.** `GetOrCompute(Ex)` registers a `computeToken` (stored in the writeQueue, guarded by its mutex) before running the evaluator. `Delete`/`DeletePredicate`/`DeleteWithPrefix`/`DeleteRegExp`/`Purge` mark matching tokens inside the same critical section that enqueues their op and removes overridden queued Sets; the write-back goes through `TrySet`, which checks the token in that same critical section. A compute fenced mid-flight still returns its value to the caller but never resurrects pre-invalidation data: a fresh write can neither be enqueued after the invalidation (token mark) nor survive in front of it (removeOverridden + FIFO ordering behind the queued invalidation op). `Delete` additionally holds the per-key compute lock, as before.

**M12 — invalidation delivery semantics.** Invalidations stay enqueue-only and always return nil — by owner decision, latency wins over caller-visible errors. What this PR adds against the audit finding: a failing engine op is now **retried head-of-line every tick until it succeeds** (the M10 fix makes that sane — see below), failures are logged, `Close()` drains the queue on graceful shutdown (deploys no longer lose queued invalidations), and post-PR-8 TTLs backstop the residual hard-crash window (≤1s + backlog). Reads see invalidations immediately via the queued op, so read-your-delete holds throughout.

**M10 — purge error shadow.** The write loop's `queueOperationPurge` case declared `err :=`, shadowing the outer error, so a failing purge hot-spun silently with zero backoff, starving all queued writes. The dispatch now lives in `runOneWriteCycle` with a single `err` declaration; a failing op is attempted once per tick, logged, and left at the front for the next tick.

**Q3 + bulk deletes — `RedisCache.Keys` uses SCAN** (COUNT 1000) instead of KEYS, and a new additive **`BulkDeleter`** interface (`DeleteMany`) lets the write loop's predicate case delete matching keys in batched variadic `UNLINK`s (500 keys/command) instead of one DEL round trip per key. `RedisCache.Purge` now goes through `DeleteMany` too (resolving its old FIXME): purging ~200k keys drops from ~200k round trips to ~400, all in the background.

**Q12 — additive `Close()`.** Stops the ticker, waits for the write loop to run its final best-effort drain and exit, then runs one more drain to catch ops that raced it (safe: the loop goroutine is gone, engineMu serializes cycles). Idempotent; nil-safe on caches built without `MakeCache`. **Shutdown trap, called out explicitly:** a write or invalidation enqueued after Close never reaches the engine — it only masks in-process reads, and against redis (which outlives the process) a lost invalidation means a freshly started instance serves the stale key. g2 PR 12 must quiesce **every** invalidation producer — HTTP listener, dataset event listener, background workers — before calling Close.

## Consumer-visible changes (g2 is the sole production consumer — confirmed)

- Invalidation latency is unchanged from today (enqueue-and-return); no new inline engine round trips anywhere.
- `Delete*/Purge` still return nil unconditionally — g2's invalidation error checks remain dead code (accepted; write-loop logs + retry-until-success are the failure story).
- Read-your-delete still holds (queued ops mask in-process reads; g2 is single-instance) — the s3_cache_worker delete-then-Compute idiom is unaffected.
- `CacheWithSubcache` (unused by g2): behavior unchanged from released v1.2.5 (its Delete/Purge chain through the still-async, still-nil-returning paths).
- Known granularity limit (pre-existing to the link feature, documented in code): a predicate matching only a derived link key — not the compute's primary key — marks no token; such writes are only caught while still queued.

## Tests

Red-first commits (house pattern): commit 1 adds tests that compile against unmodified code and fail on the real bugs; later commits make them green, then rework the delivery-semantics tests to pin the async contract: mask-immediately/remove-on-flush, retry-until-recovery, invalidation never blocks on an in-flight engine write (FIFO cleanup verified), bulk fast-path dispatch, multi-batch UNLINK purge against miniredis, post-Close invalidations documented as in-process-only. The H4 fencing tests are untouched across the pivot — the fencing mechanism is identical in both designs. `go test -race ./...` is green except the pre-existing `utils.TestMutexMap` race on master (unchanged baseline).

Four independent review passes ran (three on the original design verifying the full locking-invariant set, one focused on the async rework delta) — the rework reviewer confirmed the H4 interleaving argument, the DoneWriting front-guard under racing removeOverridden, read-masking with no stale window, deleteKeys/flushWriteQueue lockstep, and DeleteMany batch bounds; its one finding (the Close shutdown trap) is addressed in the last commit.

## Release / sequencing

Do NOT tag a release off this PR — PR 11 (`fix/keys-count-subcache`, L5+L6) lands next in the same files, then one release (**v1.3.0**) pins both and g2 PR 12 bumps to it. Note for PR 11: the write queue still carries all four op types (delete tombstones, predicate ops, purges) — the sync design's "tombstone-free queue" simplification no longer applies to L5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)