### PR TITLE
dedupe Keys()/CountPredicate, mask tombstoned keys, nil-guard CacheWithSubcache.Get (L5, L6)

### DIFF
--- a/cache_with_subcache.go
+++ b/cache_with_subcache.go
@@ -13,8 +13,16 @@ func (cs *CacheWithSubcache[T]) Get(key string) (interface{}, error) {
 	value, err := cs.Subcache.GetOrCompute(key, func() (*T, error) {
 		return cs.Cache.Get(key)
 	})
+	if err != nil {
+		var zero T
+		return zero, err
+	}
+	if value == nil {
+		var zero T
+		return zero, ErrNotFound
+	}
 
-	return *value, err
+	return *value, nil
 }
 
 // Peek gets a cached key value without side-effects (i.e. without adding to L1 cache)

--- a/cache_with_subcache_test.go
+++ b/cache_with_subcache_test.go
@@ -23,3 +23,20 @@ func TestCacheWithSubcacheGetMissReturnsError(t *testing.T) {
 	assert.ErrorIs(t, err, ErrNotFound)
 	assert.Equal(t, testEntry{}, value)
 }
+
+// A hit in the primary cache is served and promoted into the L1 subcache.
+func TestCacheWithSubcacheGetHit(t *testing.T) {
+	cs := &CacheWithSubcache[testEntry]{
+		Cache:    newTestCache[testEntry](newFakeEngine()),
+		Subcache: newTestCache[testEntry](newFakeEngine()),
+	}
+	require.NoError(t, cs.Cache.Set("hit", &testEntry{ID: 7, Key: "hit"}))
+
+	value, err := cs.Get("hit")
+	require.NoError(t, err)
+	assert.Equal(t, testEntry{ID: 7, Key: "hit"}, value)
+
+	promoted, err := cs.Subcache.Get("hit")
+	require.NoError(t, err)
+	assert.Equal(t, testEntry{ID: 7, Key: "hit"}, *promoted)
+}

--- a/cache_with_subcache_test.go
+++ b/cache_with_subcache_test.go
@@ -1,0 +1,25 @@
+package cachier
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A miss in both layers must surface ErrNotFound instead of dereferencing
+// the nil compute result (L6).
+func TestCacheWithSubcacheGetMissReturnsError(t *testing.T) {
+	cs := &CacheWithSubcache[testEntry]{
+		Cache:    newTestCache[testEntry](newFakeEngine()),
+		Subcache: newTestCache[testEntry](newFakeEngine()),
+	}
+
+	var value interface{}
+	var err error
+	require.NotPanics(t, func() {
+		value, err = cs.Get("missing")
+	})
+	assert.ErrorIs(t, err, ErrNotFound)
+	assert.Equal(t, testEntry{}, value)
+}

--- a/interface.go
+++ b/interface.go
@@ -23,7 +23,6 @@ package cachier
 import (
 	"errors"
 	"regexp"
-	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -276,13 +275,12 @@ func (c *Cache[T]) DeleteRegExp(pattern string) error {
 
 // CountPredicate counts cache keys satisfying the given predicate
 func (c *Cache[T]) CountPredicate(pred Predicate) (int, error) {
-	count := c.writeQueue.CountPredicate(pred)
-
 	keys, err := c.Keys()
 	if err != nil {
 		return 0, err
 	}
 
+	count := 0
 	for _, key := range keys {
 		if pred(key) {
 			count++
@@ -347,11 +345,34 @@ func (c *Cache[T]) Purge() error {
 	return nil
 }
 
-// Keys returns all the keys in cache
+// Keys returns all the keys in cache: keys with a pending write in the
+// queue plus engine keys, matching what Get/Peek would serve — the union
+// is deduplicated (an updated key sits in both sources until the write
+// loop flushes it) and engine keys masked by a queued delete/predicate/
+// purge are excluded. The queue snapshot is taken before the engine one so
+// a key flushed between the two calls still appears (as a deduped engine
+// key) instead of being dropped; the seen set also absorbs the duplicates
+// a redis SCAN may legitimately return.
 func (c *Cache[T]) Keys() ([]string, error) {
-	writeQueueKeys := c.writeQueue.Keys()
+	keys := c.writeQueue.Keys()
 	engineKeys, err := c.engine.Keys()
-	return slices.Concat(writeQueueKeys, engineKeys), err
+	if err != nil {
+		return nil, err
+	}
+
+	seen := make(map[string]struct{}, len(keys)+len(engineKeys))
+	for _, key := range keys {
+		seen[key] = struct{}{}
+	}
+	for _, key := range c.writeQueue.Unmasked(engineKeys) {
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		keys = append(keys, key)
+	}
+
+	return keys, nil
 }
 
 // getNoLock gets a cached value by key

--- a/keys_count_test.go
+++ b/keys_count_test.go
@@ -1,0 +1,102 @@
+package cachier
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// countKey returns how many times key occurs in keys.
+func countKey(keys []string, key string) int {
+	count := 0
+	for _, k := range keys {
+		if k == key {
+			count++
+		}
+	}
+	return count
+}
+
+// A key that was flushed to the engine and then updated sits in both the
+// write queue and the engine; Keys must report it once (L5).
+func TestKeysDedupesQueueAndEngine(t *testing.T) {
+	c := newTestCache[testEntry](newFakeEngine())
+
+	require.NoError(t, c.Set("updated", &testEntry{ID: 1}))
+	flushWriteQueue(t, c)
+	require.NoError(t, c.Set("updated", &testEntry{ID: 2}))
+	require.NoError(t, c.Set("pending", &testEntry{ID: 3}))
+
+	keys, err := c.Keys()
+	require.NoError(t, err)
+	assert.Equal(t, 1, countKey(keys, "updated"))
+	assert.Equal(t, 1, countKey(keys, "pending"))
+	assert.Len(t, keys, 2)
+}
+
+// CountPredicate used to count the write queue separately and then iterate
+// Keys(), which already includes the queue — every unflushed key counted
+// twice (L5).
+func TestCountPredicateCountsUnflushedKeyOnce(t *testing.T) {
+	c := newTestCache[testEntry](newFakeEngine())
+
+	require.NoError(t, c.Set("updated", &testEntry{ID: 1}))
+	flushWriteQueue(t, c)
+	require.NoError(t, c.Set("updated", &testEntry{ID: 2}))
+
+	count, err := c.CountPredicate(func(string) bool { return true })
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+}
+
+// A queued delete masks the key for Get/Peek; Keys and CountPredicate must
+// exclude it the same way even though the engine still holds it until the
+// write loop flushes the tombstone (L5).
+func TestKeysExcludesKeyPendingDeletion(t *testing.T) {
+	c := newTestCache[testEntry](newFakeEngine())
+
+	require.NoError(t, c.Set("doomed", &testEntry{ID: 1}))
+	require.NoError(t, c.Set("kept", &testEntry{ID: 2}))
+	flushWriteQueue(t, c)
+	require.NoError(t, c.Delete("doomed"))
+
+	keys, err := c.Keys()
+	require.NoError(t, err)
+	assert.Equal(t, []string{"kept"}, keys)
+
+	count, err := c.CountPredicate(func(string) bool { return true })
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+}
+
+func TestKeysExcludesKeysPendingPredicateDeletion(t *testing.T) {
+	c := newTestCache[testEntry](newFakeEngine())
+
+	require.NoError(t, c.Set("tag:a", &testEntry{ID: 1}))
+	require.NoError(t, c.Set("tag:b", &testEntry{ID: 2}))
+	require.NoError(t, c.Set("other", &testEntry{ID: 3}))
+	flushWriteQueue(t, c)
+	require.NoError(t, c.DeleteWithPrefix("tag:"))
+
+	keys, err := c.Keys()
+	require.NoError(t, err)
+	assert.Equal(t, []string{"other"}, keys)
+}
+
+func TestKeysExcludesEverythingAfterPurge(t *testing.T) {
+	c := newTestCache[testEntry](newFakeEngine())
+
+	require.NoError(t, c.Set("k1", &testEntry{ID: 1}))
+	require.NoError(t, c.Set("k2", &testEntry{ID: 2}))
+	flushWriteQueue(t, c)
+	require.NoError(t, c.Purge())
+
+	keys, err := c.Keys()
+	require.NoError(t, err)
+	assert.Empty(t, keys)
+
+	count, err := c.CountPredicate(func(string) bool { return true })
+	require.NoError(t, err)
+	assert.Equal(t, 0, count)
+}

--- a/keys_count_test.go
+++ b/keys_count_test.go
@@ -1,6 +1,7 @@
 package cachier
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -98,5 +99,22 @@ func TestKeysExcludesEverythingAfterPurge(t *testing.T) {
 
 	count, err := c.CountPredicate(func(string) bool { return true })
 	require.NoError(t, err)
+	assert.Equal(t, 0, count)
+}
+
+// An engine listing failure yields no keys at all rather than a partial
+// (queue-only) listing next to a non-nil error.
+func TestKeysPropagatesEngineError(t *testing.T) {
+	engine := newFakeEngine()
+	engine.keysErr = errors.New("scan failed")
+	c := newTestCache[testEntry](engine)
+	require.NoError(t, c.Set("pending", &testEntry{ID: 1}))
+
+	keys, err := c.Keys()
+	assert.ErrorIs(t, err, engine.keysErr)
+	assert.Nil(t, keys)
+
+	count, err := c.CountPredicate(func(string) bool { return true })
+	assert.ErrorIs(t, err, engine.keysErr)
 	assert.Equal(t, 0, count)
 }

--- a/write_queue.go
+++ b/write_queue.go
@@ -286,21 +286,6 @@ func (q *writeQueue[T]) Count() int {
 	return len(q.Values)
 }
 
-// CountPredicate counts the number of keys in the queue that satisfy the given predicate
-func (q *writeQueue[T]) CountPredicate(pred Predicate) int {
-	q.Lock()
-	defer q.Unlock()
-
-	count := 0
-	for key := range q.Values {
-		if pred(key) {
-			count++ // Count valid keys that satisfy the predicate
-		}
-	}
-
-	return count // Return the total count
-}
-
 // Purge removes all records from the queue and marks every in-flight
 // compute token
 func (q *writeQueue[T]) Purge() {
@@ -328,6 +313,38 @@ func (q *writeQueue[T]) Keys() []string {
 	}
 
 	return keys // Return the list of all keys
+}
+
+// Unmasked returns the subset of keys currently visible to readers, using
+// the same visibility rule as Get: a key with a pending Set stays visible,
+// while a key masked by a queued Delete/DeletePredicate/Purge operation is
+// treated as deleted before the write loop flushes the operation to the
+// engine. Checking Values first also keeps a concurrently updated engine
+// key from being dropped: a Set op in the queue always has a Values entry
+// (every delete path scrubs both under this mutex).
+func (q *writeQueue[T]) Unmasked(keys []string) []string {
+	q.Lock()
+	defer q.Unlock()
+
+	unmasked := make([]string, 0, len(keys))
+	for _, key := range keys {
+		if _, pending := q.Values[key]; pending {
+			unmasked = append(unmasked, key)
+			continue
+		}
+		masked := false
+		for it := range q.Queue.Iter() {
+			if it.IncludesKey(key) {
+				masked = true
+				break
+			}
+		}
+		if !masked {
+			unmasked = append(unmasked, key)
+		}
+	}
+
+	return unmasked
 }
 
 // StartWriting removes the oldest key-value pair from the queue

--- a/write_queue_test.go
+++ b/write_queue_test.go
@@ -186,29 +186,24 @@ func TestWriteQueue_Count(t *testing.T) {
 	assert.Equal(t, 0, q.Count())
 }
 
-func TestWriteQueue_CountPredicate(t *testing.T) {
+func TestWriteQueue_Unmasked(t *testing.T) {
 	q := newWriteQueue[string]()
 
-	// Add values
-	value1 := "value1"
-	value2 := "value2"
-	value3 := "value3"
-	q.Set("test_key1", &value1)
-	q.Set("test_key2", &value2)
-	q.Set("other_key", &value3)
+	value := "value"
+	q.Set("pending", &value)
+	q.Delete("deleted")
+	q.DeletePredicate(func(key string) bool {
+		return strings.HasPrefix(key, "pref_")
+	})
 
-	// Count keys starting with "test_"
-	predicate := func(key string) bool {
-		return strings.HasPrefix(key, "test_")
-	}
+	// A pending Set stays visible, keys masked by queued delete ops are
+	// dropped, untouched keys pass through.
+	keys := q.Unmasked([]string{"pending", "deleted", "pref_key", "clean"})
+	assert.Equal(t, []string{"pending", "clean"}, keys)
 
-	count := q.CountPredicate(predicate)
-	assert.Equal(t, 2, count)
-
-	// Delete one matching key
-	q.Delete("test_key1")
-	count = q.CountPredicate(predicate)
-	assert.Equal(t, 1, count)
+	// Purge masks everything.
+	q.Purge()
+	assert.Empty(t, q.Unmasked([]string{"pending", "clean"}))
 }
 
 func TestWriteQueue_Keys(t *testing.T) {
@@ -713,9 +708,7 @@ func TestWriteQueue_EmptyQueue_EdgeCases(t *testing.T) {
 	// Operations on empty queue
 	assert.Equal(t, 0, q.Count())
 	assert.Equal(t, 0, len(q.Keys()))
-
-	predicate := func(key string) bool { return true }
-	assert.Equal(t, 0, q.CountPredicate(predicate))
+	assert.Equal(t, []string{"any"}, q.Unmasked([]string{"any"}))
 
 	// Get from empty queue
 	result, found := q.Get("nonexistent")
@@ -759,7 +752,12 @@ func TestWriteQueue_LargeOperations(t *testing.T) {
 		}
 	}
 
-	count := q.CountPredicate(predicate)
+	count := 0
+	for _, key := range q.Keys() {
+		if predicate(key) {
+			count++
+		}
+	}
 	assert.Equal(t, expectedMatches, count)
 
 	// Delete with predicate


### PR DESCRIPTION
PR 11 of the g2 cache remediation plan — the last cachier change before the v1.3.0 tag.

## L5 — Keys() duplicates and CountPredicate double count

`Keys()` concatenated `writeQueue.Keys()` with `engine.Keys()`, so an updated key pending in the queue and already flushed to the engine appeared twice; `CountPredicate` additionally counted the write queue separately and then iterated `Keys()` (which already includes the queue), double-counting every unflushed key. Keys masked by a queued `Delete`/`DeletePredicate`/`Purge` were invisible to `Get`/`Peek` but still listed and counted from the engine side.

Now `Keys()` returns the read-consistent union:

- the queue snapshot is taken **before** the engine one, so a key flushed between the two calls dedupes instead of being dropped;
- engine keys are filtered through the new `writeQueue.Unmasked`, which applies `Get`'s exact visibility rule (`Values` hit ⇒ visible; otherwise masked iff a queued op `IncludesKey`s it) under one lock — the `Values`-first check also keeps a concurrently updated engine key from being masked by its own pending Set;
- the seen-set dedupe additionally absorbs the duplicates a redis SCAN may legitimately return.

`CountPredicate` iterates that union once; `writeQueue.CountPredicate` loses its last caller and is removed.

**Behavior changes for callers:**
- `Keys()`/`CountPredicate`/`CountRegExp` stop inflating (g2's run-cache admin count endpoint will report accurate, possibly lower numbers) and stop listing keys pending deletion.
- On an engine listing error `Keys()` now returns `nil` instead of a partial queue-only listing next to the error (no caller consumed the partial result; verified in g2).

## L6 — CacheWithSubcache.Get nil deref

`Get` dereferenced the `GetOrCompute` result unconditionally, panicking on any miss or engine error. It now returns zero `T` + the error (`ErrNotFound` on a nil value). The exported type is kept as-is — g2 has no references, but external consumers are unknown.

## Tests

Red commit first (compiles against unmodified code, all six tests red on master), fix commit second. `go test -race ./...`: root package and `compression` green; `utils.TestMutexMap` race is the pre-existing baseline failure on master, untouched here.

## After merge

Tag **v1.3.0** on master (v-prefixed — a bare tag is invisible to Go modules) containing both the #22 merge and this one, then g2 PR 12 bumps the pin and wires `Close()` into graceful shutdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)